### PR TITLE
Fixing version test to allow 1.12.21 version

### DIFF
--- a/tests/Zend/VersionTest.php
+++ b/tests/Zend/VersionTest.php
@@ -55,7 +55,7 @@ class Zend_VersionTest extends PHPUnit_Framework_TestCase
         // unit test breaks if ZF version > 1.x
         for ($i=0; $i <= 1; $i++) {
             for ($j=0; $j <= 12; $j++) {
-                for ($k=0; $k < 20; $k++) {
+                for ($k=0; $k <= 21; $k++) {
                     foreach (array('dev', 'pr', 'PR', 'alpha', 'a1', 'a2', 'beta', 'b1', 'b2', 'RC', 'RC1', 'RC2', 'RC3', '', 'pl1', 'PL1') as $rel) {
                         $ver = "$i.$j.$k$rel";
                         $normalizedVersion = strtolower(Zend_Version::VERSION);


### PR DESCRIPTION
This will allow travis tests to pass.  Not sure the best approach for
the future of this file yet, probably depends if we’re going to be
bumping the version or not in our apps.