### PR TITLE
PHP 7.2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tests/Zend/Translate/Adapter/_files/zend_cache---testid
 tests/TestConfiguration.php
 tests/Zend/Session/_files/*
 tests/Zend/Cache/zend_cache_tmp_dir_*
+tests/Zend/Config/Writer/temp/*
 vendor/*
 composer.lock
 bin/dbunit

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor/*
 composer.lock
 bin/dbunit
 bin/phpunit
+build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,3 @@ script:
 
 matrix:
   allow_failures:
-   - php: 7.2

--- a/demos/Zend/Mobile/Push/ApnsFeedback.php
+++ b/demos/Zend/Mobile/Push/ApnsFeedback.php
@@ -3,7 +3,7 @@ require_once 'Zend/Mobile/Push/Apns.php';
 
 $apns = new Zend_Mobile_Push_Apns();
 $apns->setCertificate('/path/to/provisioning-certificate.pem');
- 
+
 try {
     $apns->connect(Zend_Mobile_Push_Apns::SERVER_FEEDBACK_SANDBOX_URI);
 } catch (Zend_Mobile_Push_Exception_ServerUnavailable $e) {
@@ -13,9 +13,9 @@ try {
     echo 'APNS Connection Error:' . $e->getMessage();
     exit(1);
 }
- 
+
 $tokens = $apns->feedback();
-while(list($token, $time) = each($tokens)) {
+foreach ($tokens as $token => $time) {
     echo $time . "\t" . $token . PHP_EOL;
 }
 $apns->close();

--- a/documentation/manual/en/module_specs/Zend_Mobile_Push-Apns.xml
+++ b/documentation/manual/en/module_specs/Zend_Mobile_Push-Apns.xml
@@ -152,12 +152,12 @@ try {
 }
 
 $tokens = $apns->feedback();
-while(list($token, $time) = each($tokens)) {
+foreach ($tokens as $token => $time) {
     echo $time . "\t" . $token . PHP_EOL;
 }
 $apns->close();
 ]]></programlisting>
-        
+
     </sect2>
 
     <sect2 id="zend.mobile.push.apns.message">

--- a/library/Zend/Cache/Backend.php
+++ b/library/Zend/Cache/Backend.php
@@ -76,7 +76,7 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
+        foreach ($directives as $name => $value) {
             if (!is_string($name)) {
                 Zend_Cache::throwException("Incorrect option name : $name");
             }

--- a/library/Zend/Config/Yaml.php
+++ b/library/Zend/Config/Yaml.php
@@ -202,7 +202,7 @@ class Zend_Config_Yaml extends Zend_Config
                 if (!isset($config[$sectionName])) {
                     require_once 'Zend/Config/Exception.php';
                     throw new Zend_Config_Exception(sprintf(
-                        'Section "%s" cannot be found', 
+                        'Section "%s" cannot be found',
                         implode(' ', (array)$section)
                     ));
                 }
@@ -214,7 +214,7 @@ class Zend_Config_Yaml extends Zend_Config
             if (!isset($config[$section])) {
                 require_once 'Zend/Config/Exception.php';
                 throw new Zend_Config_Exception(sprintf(
-                    'Section "%s" cannot be found', 
+                    'Section "%s" cannot be found',
                     implode(' ', (array)$section)
                 ));
             }
@@ -289,8 +289,10 @@ class Zend_Config_Yaml extends Zend_Config
     {
         $config   = array();
         $inIndent = false;
-        while (list($n, $line) = each($lines)) {
-            $lineno = $n + 1;
+        while (key($lines) !== null) {
+            $line = current($lines);
+            $lineno = key($lines) + 1;
+            next($lines);
 
             $line = rtrim(preg_replace("/#.*$/", "", $line));
             if (strlen($line) == 0) {

--- a/library/Zend/Config/Yaml.php
+++ b/library/Zend/Config/Yaml.php
@@ -365,10 +365,10 @@ class Zend_Config_Yaml extends Zend_Config
 
         // remove quotes from string.
         if ('"' == $value['0']) {
-            if ('"' == $value[count($value) -1]) {
+            if ('"' == $value[strlen($value) -1]) {
                 $value = substr($value, 1, -1);
             }
-        } elseif ('\'' == $value['0'] && '\'' == $value[count($value) -1]) {
+        } elseif ('\'' == $value['0'] && '\'' == $value[strlen($value) -1]) {
             $value = strtr($value, array("''" => "'", "'" => ''));
         }
 

--- a/library/Zend/Date/DateObject.php
+++ b/library/Zend/Date/DateObject.php
@@ -313,10 +313,10 @@ abstract class Zend_Date_DateObject {
 
         if (abs($timestamp) <= 0x7FFFFFFF) {
             // See ZF-11992
-            // "o" will sometimes resolve to the previous year (see 
-            // http://php.net/date ; it's part of the ISO 8601 
-            // standard). However, this is not desired, so replacing 
-            // all occurrences of "o" not preceded by a backslash 
+            // "o" will sometimes resolve to the previous year (see
+            // http://php.net/date ; it's part of the ISO 8601
+            // standard). However, this is not desired, so replacing
+            // all occurrences of "o" not preceded by a backslash
             // with "Y"
             $format = preg_replace('/(?<!\\\\)o/', 'Y', $format);
             $result = ($gmt) ? @gmdate($format, $timestamp) : @date($format, $timestamp);

--- a/library/Zend/Db/Table/Abstract.php
+++ b/library/Zend/Db/Table/Abstract.php
@@ -1304,13 +1304,13 @@ abstract class Zend_Db_Table_Abstract
         $whereList = array();
         $numberTerms = 0;
         foreach ($args as $keyPosition => $keyValues) {
-            $keyValuesCount = count($keyValues);
             // Coerce the values to an array.
             // Don't simply typecast to array, because the values
             // might be Zend_Db_Expr objects.
             if (!is_array($keyValues)) {
                 $keyValues = array($keyValues);
             }
+            $keyValuesCount = count($keyValues);
             if ($numberTerms == 0) {
                 $numberTerms = $keyValuesCount;
             } else if ($keyValuesCount != $numberTerms) {

--- a/library/Zend/Feed/Reader/Entry/Rss.php
+++ b/library/Zend/Feed/Reader/Entry/Rss.php
@@ -201,7 +201,7 @@ class Zend_Feed_Reader_Entry_Rss extends Zend_Feed_Reader_EntryAbstract implemen
             );
         }
 
-        if (count($authors) == 0) {
+        if ($authors !== null && count($authors) == 0) {
             $authors = null;
         }
 

--- a/library/Zend/Feed/Reader/Feed/Rss.php
+++ b/library/Zend/Feed/Reader/Feed/Rss.php
@@ -151,7 +151,7 @@ class Zend_Feed_Reader_Feed_Rss extends Zend_Feed_Reader_FeedAbstract
             );
         }
 
-        if (count($authors) == 0) {
+        if ($authors !== null && count($authors) == 0) {
             $authors = null;
         }
 

--- a/library/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
+++ b/library/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
@@ -88,7 +88,7 @@ class Zend_Http_UserAgent_Features_Adapter_TeraWurfl implements Zend_Http_UserAg
             if (!is_array($group)) {
                 continue;
             }
-            while (list ($key, $value) = each($group)) {
+            foreach ($group as $key => $value) {
                 if (is_bool($value)) {
                     // to have the same type than the official WURFL API
                     $features[$key] = ($value ? 'true' : 'false');

--- a/library/Zend/Mail/Part.php
+++ b/library/Zend/Mail/Part.php
@@ -47,7 +47,7 @@ require_once 'Zend/Mail/Part/Interface.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
+class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Countable
 {
     /**
      * headers of part as array
@@ -96,10 +96,10 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      * @var int
      */
     protected $_messageNum = 0;
-    
+
     /**
      * Class to use when creating message parts
-     * @var string 
+     * @var string
      */
     protected $_partClass;
 
@@ -138,7 +138,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
             $this->_mail       = $params['handler'];
             $this->_messageNum = $params['id'];
         }
-        
+
         if (isset($params['partclass'])) {
             $this->setPartClass($params['partclass']);
         }
@@ -162,7 +162,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
             }
         }
     }
-    
+
     /**
      * Set name pf class used to encapsulate message parts
      * @param string $class
@@ -184,14 +184,14 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
             require_once 'Zend/Mail/Exception.php';
             throw new Zend_Mail_Exception("Class '{$class}' must implement Zend_Mail_Part_Interface");
         }
-        
+
         $this->_partClass = $class;
         return $this;
     }
-    
+
     /**
      * Retrieve the class name used to encapsulate message parts
-     * @return string 
+     * @return string
      */
     public function getPartClass()
     {
@@ -577,6 +577,11 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
     {
         $this->countParts();
         $this->_iterationPos = 1;
+    }
+
+    public function count()
+    {
+        return $this->countParts();
     }
 
     /**

--- a/library/Zend/Oauth/Token.php
+++ b/library/Zend/Oauth/Token.php
@@ -71,7 +71,7 @@ abstract class Zend_Oauth_Token
         if ($response !== null) {
             $this->_response = $response;
             $params = $this->_parseParameters($response);
-            if (count($params) > 0) {
+            if ($params !== null && count($params) > 0) {
                 $this->setParams($params);
             }
         }

--- a/library/Zend/Rest/Route.php
+++ b/library/Zend/Rest/Route.php
@@ -236,12 +236,14 @@ class Zend_Rest_Route extends Zend_Controller_Router_Route_Module
     /**
      * Assembles user submitted parameters forming a URL path defined by this route
      *
-     * @param array $data An array of variable and value pairs used as parameters
-     * @param bool $reset Weither to reset the current params
-     * @param bool $encode Weither to return urlencoded string
+     * @param array $data   An array of variable and value pairs used as parameters
+     * @param bool  $reset  Weither to reset the current params
+     * @param bool  $encode Weither to return urlencoded string
+     * @param bool  $partial
+     *
      * @return string Route path with user submitted parameters
      */
-    public function assemble($data = array(), $reset = false, $encode = true)
+    public function assemble($data = array(), $reset = false, $encode = true, $partial = false)
     {
         if (!$this->_keysSet) {
             if (null === $this->_request) {

--- a/library/Zend/Test/DbStatement.php
+++ b/library/Zend/Test/DbStatement.php
@@ -140,7 +140,11 @@ class Zend_Test_DbStatement implements Zend_Db_Statement_Interface
      */
     public function append($row)
     {
-        $this->_columnCount = count($row);
+        if (!is_array($row)) {
+            $this->_columnCount = 1;
+        } else {
+            $this->_columnCount = count($row);
+        }
         $this->_fetchStack[] = $row;
     }
 

--- a/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -383,7 +383,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      */
     public function hasChildren()
     {
-        return (count($this->_subResources > 0)) ? true : false;
+        return (count($this->_subResources) > 0) ? true : false;
     }
 
     /**

--- a/library/Zend/Validate/EmailAddress.php
+++ b/library/Zend/Validate/EmailAddress.php
@@ -453,7 +453,7 @@ class Zend_Validate_EmailAddress extends Zend_Validate_Abstract
 
         //decode IDN domain name if possible
         if (function_exists('idn_to_ascii')) {
-            $hostname = idn_to_ascii($this->_hostname);
+            $hostname = idn_to_ascii($this->_hostname, 0, INTL_IDNA_VARIANT_UTS46);
         }
 
         $result = getmxrr($hostname, $mxHosts);

--- a/library/Zend/Validate/File/Upload.php
+++ b/library/Zend/Validate/File/Upload.php
@@ -129,7 +129,7 @@ class Zend_Validate_File_Upload extends Zend_Validate_Abstract
      */
     public function setFiles($files = array())
     {
-        if (count($files) === 0) {
+        if ($files === null || count($files) === 0) {
             $this->_files = $_FILES;
         } else {
             $this->_files = $files;

--- a/library/Zend/XmlRpc/Value.php
+++ b/library/Zend/XmlRpc/Value.php
@@ -486,13 +486,17 @@ abstract class Zend_XmlRpc_Value
      */
     protected static function _extractTypeAndValue(SimpleXMLElement $xml, &$type, &$value)
     {
-        list($type, $value) = each($xml);
+        $type = key($xml);
+        $value = current($xml);
+        next($xml);
 
-        if (!$type and $value === null) {
+        if ($type === null && $value === false) {
             $namespaces = array('ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions');
             foreach ($namespaces as $namespaceName => $namespaceUri) {
                 $namespaceXml = $xml->children($namespaceUri);
-                list($type, $value) = each($namespaceXml);
+                $type = key($namespaceXml);
+                $value = current($namespaceXml);
+                next($namespaceXml);
                 if ($type !== null) {
                     $type = $namespaceName . ':' . $type;
                     break;

--- a/tests/Zend/Amf/RequestTest.php
+++ b/tests/Zend/Amf/RequestTest.php
@@ -433,7 +433,14 @@ class Zend_Amf_RequestTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($bodies[0] instanceof Zend_Amf_Value_MessageBody);
         $data = $bodies[0]->getData();
         // Make sure that the string was deserialized properly and check its value
-        $this->assertTrue(array_key_exists(1, get_object_vars($data[0])));
+        // In PHP versions less than 7, get_object_vars doesn't return numerical
+        // keys. In PHP 7.2+ array_key_exists on this particular object returns false
+        // https://3v4l.org/ui8Fm
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            $this->assertTrue(array_key_exists(1, get_object_vars($data[0])));
+        } else {
+            $this->assertTrue(array_key_exists(1, $data[0]));
+        }
         $this->assertEquals('two', $data[0]->two);
     }
 

--- a/tests/Zend/Amf/RequestTest.php
+++ b/tests/Zend/Amf/RequestTest.php
@@ -425,7 +425,7 @@ class Zend_Amf_RequestTest extends PHPUnit_Framework_TestCase
         $myRequest = file_get_contents(dirname(__FILE__) .'/Request/mock/mixedArrayAmf0Request.bin');
         // send the mock object request to be deserialized
         $this->_request->initialize($myRequest);
-        // Make sure that no headers where recieved
+        // Make sure that no headers were recieved
         $this->assertEquals(0 , sizeof($this->_request->getAmfHeaders()));
         // Make sure that the message body was set after deserialization
         $this->assertEquals(1, sizeof($this->_request->getAmfBodies()));
@@ -433,7 +433,7 @@ class Zend_Amf_RequestTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($bodies[0] instanceof Zend_Amf_Value_MessageBody);
         $data = $bodies[0]->getData();
         // Make sure that the string was deserialized properly and check its value
-        $this->assertTrue(array_key_exists(1, $data[0]));
+        $this->assertTrue(array_key_exists(1, get_object_vars($data[0])));
         $this->assertEquals('two', $data[0]->two);
     }
 
@@ -666,4 +666,3 @@ class Zend_Amf_RequestTest extends PHPUnit_Framework_TestCase
 if (PHPUnit_MAIN_METHOD == 'Zend_Amf_RequestTest::main') {
     Zend_Amf_RequestTest::main();
 }
-

--- a/tests/Zend/Controller/Router/Route/ChainTest.php
+++ b/tests/Zend/Controller/Router/Route/ChainTest.php
@@ -1015,7 +1015,7 @@ class Zend_Controller_Router_Route_SimpleSubclassTest extends Zend_Controller_Ro
         return 2;
     }
 
-    public function assemble($data = array(), $reset = false, $encode = false)
+    public function assemble($data = array(), $reset = false, $encode = false, $partial = false)
     {}
 
     public static function getInstance(Zend_Config $config)
@@ -1040,7 +1040,7 @@ class Zend_Controller_Router_Route_SubclassTest extends Zend_Controller_Router_R
         return 2;
     }
 
-    public function assemble($data = array(), $reset = false, $encode = false)
+    public function assemble($data = array(), $reset = false, $encode = false, $partial = false)
     {}
 
     public static function getInstance(Zend_Config $config)

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -276,40 +276,86 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
     public function testCalcSunInternal()
     {
         $date = new Zend_Date_DateObjectTestHelper(10000000);
-        $this->assertSame( 9961681, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-        $this->assertSame(10010367, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-        $this->assertSame( 9967006, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-        $this->assertSame(10005042, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-        $this->assertSame( 9947773, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-        $this->assertSame( 9996438, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-        $this->assertSame( 9953077, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-        $this->assertSame( 9991134, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-        $this->assertSame( 9923795, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-        $this->assertSame( 9972422, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-        $this->assertSame( 9929062, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-        $this->assertSame( 9967155, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-        $this->assertSame( 9985660, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-        $this->assertSame(10034383, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-        $this->assertSame( 9991022, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-        $this->assertSame(10029021, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        // PHP 7.2.0+ uses a newer algorithm for sunrise/sunset calculation apparently.
+        // Seems to be changed in this commit of "timelib":
+        // https://github.com/derickr/timelib/commit/8d0066f7110d4b8bd1a745bc6628c34577c34ba5
+        // Brought into PHP in this commit:
+        // https://github.com/php/php-src/commit/bdd56f31078bf1f34341943603cf6aaa72e0db5c#diff-b1c4e94d91863a5644d2e9402ec633f1L10
+        // (which was later reverted in php < 7.2.0)
+        // Example of the difference: https://3v4l.org/v46rk
+        // Not really something we can test the same in all versions, so doing a version_compare here.
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $this->assertSame( 9961716, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
+            $this->assertSame(10010341, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
+            $this->assertSame( 9966981, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
+            $this->assertSame(10005077, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
+            $this->assertSame( 9947808, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
+            $this->assertSame( 9996412, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
+            $this->assertSame( 9953052, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
+            $this->assertSame( 9991169, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
+            $this->assertSame( 9923830, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
+            $this->assertSame( 9972397, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
+            $this->assertSame( 9929036, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
+            $this->assertSame( 9967190, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
+            $this->assertSame( 9985695, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
+            $this->assertSame(10034357, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
+            $this->assertSame( 9990996, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
+            $this->assertSame(10029056, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        } else {
+            $this->assertSame( 9961681, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
+            $this->assertSame(10010367, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
+            $this->assertSame( 9967006, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
+            $this->assertSame(10005042, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
+            $this->assertSame( 9947773, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
+            $this->assertSame( 9996438, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
+            $this->assertSame( 9953077, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
+            $this->assertSame( 9991134, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
+            $this->assertSame( 9923795, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
+            $this->assertSame( 9972422, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
+            $this->assertSame( 9929062, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
+            $this->assertSame( 9967155, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
+            $this->assertSame( 9985660, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
+            $this->assertSame(10034383, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
+            $this->assertSame( 9991022, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
+            $this->assertSame(10029021, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        }
 
         $date = new Zend_Date_DateObjectTestHelper(-148309884);
-        $this->assertSame(-148322663, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-        $this->assertSame(-148274758, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-        $this->assertSame(-148318117, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-        $this->assertSame(-148279304, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-        $this->assertSame(-148336570, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-        $this->assertSame(-148288687, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-        $this->assertSame(-148332046, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-        $this->assertSame(-148293211, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-        $this->assertSame(-148360548, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-        $this->assertSame(-148312703, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-        $this->assertSame(-148356061, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-        $this->assertSame(-148317189, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-        $this->assertSame(-148298686, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-        $this->assertSame(-148250742, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-        $this->assertSame(-148294101, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-        $this->assertSame(-148255327, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $this->assertSame(-148322626, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
+            $this->assertSame(-148274784, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
+            $this->assertSame(-148318143, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
+            $this->assertSame(-148279267, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
+            $this->assertSame(-148336533, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
+            $this->assertSame(-148288713, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
+            $this->assertSame(-148332072, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
+            $this->assertSame(-148293174, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
+            $this->assertSame(-148360510, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
+            $this->assertSame(-148312728, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
+            $this->assertSame(-148356087, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
+            $this->assertSame(-148317151, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
+            $this->assertSame(-148298649, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
+            $this->assertSame(-148250768, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
+            $this->assertSame(-148294127, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
+            $this->assertSame(-148255290, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        } else {
+            $this->assertSame(-148322663, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
+            $this->assertSame(-148274758, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
+            $this->assertSame(-148318117, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
+            $this->assertSame(-148279304, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
+            $this->assertSame(-148336570, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
+            $this->assertSame(-148288687, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
+            $this->assertSame(-148332046, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
+            $this->assertSame(-148293211, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
+            $this->assertSame(-148360548, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
+            $this->assertSame(-148312703, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
+            $this->assertSame(-148356061, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
+            $this->assertSame(-148317189, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
+            $this->assertSame(-148298686, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
+            $this->assertSame(-148250742, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
+            $this->assertSame(-148294101, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
+            $this->assertSame(-148255327, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        }
     }
 
     public function testGetDate()
@@ -539,10 +585,10 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(($diff < 2), "Zend_Date_DateObject->_getTime() returned a significantly "
             . "different timestamp than expected: $diff seconds");
     }
-    
+
     /**
      * Test for RFC 2822's Obsolete Date and Time (paragraph 4.3)
-     * 
+     *
      * @see ZF-11296
      */
     public function test_obsRfc2822()
@@ -562,7 +608,7 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
         $date = new Zend_Date('22.05.2014');
         $date->setTime('12:00');
         $date->setTimezone('America/Los_Angeles');
-    
+
         $this->assertEquals(
             $date->toString(Zend_Date::ATOM),
             $date->toString(DateTime::ATOM, 'php')

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -3818,44 +3818,78 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         $result = Zend_Date_Cities::City('vienna');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        $this->assertSame('2002-01-04T20:09:59+05:00', $result->get(Zend_Date::W3C));
+        // PHP's internal sunrise/sunset calculation changed in 7.2.0
+        // See comment in Zend/Date/DateObjectTest.php::testCalcSunInternal
+        // This applies to all of the version_compare blocks in this test
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $this->assertSame('2002-01-04T20:09:40+05:00', $result->get(Zend_Date::W3C));
+        } else {
+            $this->assertSame('2002-01-04T20:09:59+05:00', $result->get(Zend_Date::W3C));
+        }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'civil');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        $this->assertSame('2002-01-04T20:09:20+05:00', $result->get(Zend_Date::W3C));
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $this->assertSame('2002-01-04T20:09:01+05:00', $result->get(Zend_Date::W3C));
+        } else {
+            $this->assertSame('2002-01-04T20:09:20+05:00', $result->get(Zend_Date::W3C));
+        }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'nautic');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        $this->assertSame('2002-01-04T20:08:34+05:00', $result->get(Zend_Date::W3C));
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $this->assertSame('2002-01-04T20:08:15+05:00', $result->get(Zend_Date::W3C));
+        } else {
+            $this->assertSame('2002-01-04T20:08:34+05:00', $result->get(Zend_Date::W3C));
+        }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'astronomic');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        $this->assertSame('2002-01-04T20:07:49+05:00', $result->get(Zend_Date::W3C));
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $this->assertSame('2002-01-04T20:07:30+05:00', $result->get(Zend_Date::W3C));
+        } else {
+            $this->assertSame('2002-01-04T20:07:49+05:00', $result->get(Zend_Date::W3C));
+        }
 
         unset($result);
         $result = Zend_Date_Cities::City('BERLIN');
         $this->assertTrue(is_array($result));
         $result = $date->getSunrise($result);
-        $this->assertSame('2002-01-04T12:21:21+05:00', $result->get(Zend_Date::W3C));
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $this->assertSame('2002-01-04T12:21:26+05:00', $result->get(Zend_Date::W3C));
+        } else {
+            $this->assertSame('2002-01-04T12:21:21+05:00', $result->get(Zend_Date::W3C));
+        }
 
         unset($result);
         $result = Zend_Date_Cities::City('London');
         $this->assertTrue(is_array($result));
         $result = $date->getSunInfo($result);
-        $this->assertSame('2002-01-04T13:10:10+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
-        $this->assertSame('2002-01-04T13:10:54+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
-        $this->assertSame('2002-01-04T13:11:45+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
-        $this->assertSame('2002-01-04T13:12:35+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
-        $this->assertSame('2002-01-04T21:00:52+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
-        $this->assertSame('2002-01-04T21:00:08+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
-        $this->assertSame('2002-01-04T20:59:18+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
-        $this->assertSame('2002-01-04T20:58:28+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            $this->assertSame('2002-01-04T13:10:15+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
+            $this->assertSame('2002-01-04T13:10:59+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T13:11:50+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
+            $this->assertSame('2002-01-04T13:12:40+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T21:00:32+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
+            $this->assertSame('2002-01-04T20:59:48+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
+            $this->assertSame('2002-01-04T20:58:57+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T20:58:07+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
+        } else {
+            $this->assertSame('2002-01-04T13:10:10+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
+            $this->assertSame('2002-01-04T13:10:54+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T13:11:45+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
+            $this->assertSame('2002-01-04T13:12:35+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T21:00:52+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
+            $this->assertSame('2002-01-04T21:00:08+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
+            $this->assertSame('2002-01-04T20:59:18+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T20:58:28+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
+        }
 
         unset($result);
         $result = array('longitude' => 0);

--- a/tests/Zend/Db/Select/TestCommon.php
+++ b/tests/Zend/Db/Select/TestCommon.php
@@ -364,7 +364,11 @@ abstract class Zend_Db_Select_TestCommon extends Zend_Db_TestSetup
             ->query();
         $result = $stmt->fetchAll();
 
-        $this->assertNull($result);
+        if (is_array($result)) {
+            $this->assertEquals(0, count($result));
+        } else {
+            $this->assertNull($result);
+        }
     }
 
     /**

--- a/tests/Zend/Db/Select/TestCommon.php
+++ b/tests/Zend/Db/Select/TestCommon.php
@@ -363,7 +363,8 @@ abstract class Zend_Db_Select_TestCommon extends Zend_Db_TestSetup
         $stmt = $select = $this->_selectColumnWithColonQuotedParameter()
             ->query();
         $result = $stmt->fetchAll();
-        $this->assertEquals(0, count($result));
+
+        $this->assertNull($result);
     }
 
     /**

--- a/tests/Zend/DebugTest.php
+++ b/tests/Zend/DebugTest.php
@@ -51,8 +51,8 @@ class Zend_DebugTest extends PHPUnit_Framework_TestCase
         $data = 'string';
         $result = Zend_Debug::Dump($data, null, false);
         $result = str_replace(array(PHP_EOL, "\n"), '_', $result);
-        $expected = "__string(6) \"string\"__";
-        $this->assertEquals($expected, $result);
+        $expected = "__.*string\(6\) \"string\"__";
+        $this->assertRegExp('/^' . $expected . '$/', $result);
     }
 
     public function testDebugCgi()
@@ -61,12 +61,9 @@ class Zend_DebugTest extends PHPUnit_Framework_TestCase
         $data = 'string';
         $result = Zend_Debug::Dump($data, null, false);
 
-        // Has to check for two strings, because xdebug internally handles CLI vs Web
-        $this->assertContains($result,
-            array(
-                "<pre>string(6) \"string\"\n</pre>",
-                "<pre>string(6) &quot;string&quot;\n</pre>",
-            )
+        $this->assertRegExp(
+            '/^<pre>.*string\(6\) ("|&quot;)string("|&quot;)' . "\n" . '<\/pre>$/s',
+            $result
         );
     }
 
@@ -90,8 +87,8 @@ class Zend_DebugTest extends PHPUnit_Framework_TestCase
         $label = 'LABEL';
         $result = Zend_Debug::Dump($data, $label, false);
         $result = str_replace(array(PHP_EOL, "\n"), '_', $result);
-        $expected = "_{$label} _string(6) \"string\"__";
-        $this->assertEquals($expected, $result);
+        $expected = "_{$label} .*_string\(6\) \"string\"__";
+        $this->assertRegExp('/^' . $expected . '$/', $result);
     }
 
     /**

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -2790,9 +2790,10 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
     */
     public function _setup9697()
     {
-        $callback = create_function('$value, $options',
-                                    'return (isset($options["bar"]["quo"]["foo"]) &&
-                                             "foo Value" === $options["bar"]["quo"]["foo"]);');
+        $callback = function ($value, $options) {
+            return (isset($options["bar"]["quo"]["foo"]) &&
+                    "foo Value" === $options["bar"]["quo"]["foo"]);
+        };
 
         $this->form->addElement('text', 'foo')
                    ->foo->setBelongsTo('bar[quo]');
@@ -4596,7 +4597,7 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
         }
         $this->assertNotEquals($result,'');
     }
-    
+
     /**
      * @group ZF-11088
      */
@@ -4608,7 +4609,7 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
         $errorMessages = $element->getErrorMessages();
         $this->assertSame(1, count($errorMessages));
         $this->assertSame($errorString, $errorMessages[0]);
-        
+
         $element2 = new Zend_Form_Element_Text('bar');
         $this->form->addElement($element2);
         $this->form->getElement('bar')->addError($errorString);
@@ -4616,7 +4617,7 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
         $this->assertSame(1, count($errorMessages2));
         $this->assertSame($errorString, $errorMessages2[0]);
     }
-    
+
     /**
      * @group ZF-10865
      * @expectedException Zend_Form_Exception
@@ -4644,7 +4645,7 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
         $count = substr_count($html, 'randomelementname-element');
         $this->assertEquals(1, $count, $html);
     }
-    
+
     /**
      * @group ZF-11831
      */
@@ -4659,7 +4660,7 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
             'locale' => 'en'
         ));
         Zend_Registry::set('Zend_Translate', $trDefault);
-        
+
         // Translator to use for elements
         $trElement = new Zend_Translate(array(
             'adapter' => 'array',
@@ -4669,14 +4670,14 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
             'locale' => 'en'
         ));
         Zend_Validate_Abstract::setDefaultTranslator($trElement);
-        
+
         // Change the form's translator
         $form = new Zend_Form();
         $form->addElement(new Zend_Form_Element_Text('foo', array(
             'required'   => true,
             'validators' => array('NotEmpty')
         )));
-        
+
         // Create a subform with it's own validator
         $sf1 = new Zend_Form_SubForm();
         $sf1->addElement(new Zend_Form_Element_Text('foosub', array(
@@ -4684,20 +4685,20 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
             'validators' => array('NotEmpty')
         )));
         $form->addSubForm($sf1, 'Test1');
-        
+
         $form->isValid(array());
 
         $messages = $form->getMessages();
         $this->assertEquals(
-            'Element', 
-            @$messages['foo'][Zend_Validate_NotEmpty::IS_EMPTY], 
+            'Element',
+            @$messages['foo'][Zend_Validate_NotEmpty::IS_EMPTY],
             'Form element received wrong validator'
         );
         $this->assertEquals(
-            'Element', 
-            @$messages['Test1']['foosub'][Zend_Validate_NotEmpty::IS_EMPTY], 
+            'Element',
+            @$messages['Test1']['foosub'][Zend_Validate_NotEmpty::IS_EMPTY],
             'SubForm element received wrong validator'
-        );        
+        );
     }
 
     /**

--- a/tests/Zend/Gdata/AppTest.php
+++ b/tests/Zend/Gdata/AppTest.php
@@ -608,7 +608,11 @@ class Zend_Gdata_AppTest extends PHPUnit_Framework_TestCase
     public function testLoadExtensionCausesFatalErrorWhenErrorHandlerIsOverridden()
     {
         // Override the error handler to throw an ErrorException
-        set_error_handler(create_function('$a, $b, $c, $d', 'throw new ErrorException($b, 0, $a, $c, $d);'), E_ALL);
+        set_error_handler(
+            function ($a, $b, $c, $d) { throw new ErrorException($b, 0, $a, $c, $d); },
+            E_ALL
+        );
+
         try {
             $eq = $this->service->newEventQuery();
             restore_error_handler();

--- a/tests/Zend/Mail/MessageTest.php
+++ b/tests/Zend/Mail/MessageTest.php
@@ -458,7 +458,7 @@ class Zend_Mail_MessageTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(Zend_Mime_Decode::splitHeaderField($header, 'foo'), 'bar');
         $this->assertEquals(Zend_Mime_Decode::splitHeaderField($header, 'baz'), 42);
     }
-    
+
     /**
      * @group ZF-11514
      */
@@ -474,7 +474,7 @@ class Zend_Mail_MessageTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('constructor', $flags);
         $this->assertEquals('constructor', $flags['constructor']);
     }
-    
+
     /**
      * @group ZF-3745
      */
@@ -486,7 +486,7 @@ class Zend_Mail_MessageTest extends PHPUnit_Framework_TestCase
             $this->assertEquals('Zend_Mail_Part', get_class($part));
         }
     }
-    
+
     /**
      * @group ZF-3745
      */
@@ -497,14 +497,14 @@ class Zend_Mail_MessageTest extends PHPUnit_Framework_TestCase
             'partclass' => 'ZF3745_Mail_Part'
         ));
         $this->assertEquals('ZF3745_Mail_Part', $message->getPartClass());
-        
+
         // Ensure message parts use the specified part class
         $this->assertGreaterThan(0, count($message));
         foreach ( $message as $part ) {
             $this->assertEquals('ZF3745_Mail_Part', get_class($part));
         }
     }
-    
+
     /**
      * @group ZF-3745
      */
@@ -513,7 +513,7 @@ class Zend_Mail_MessageTest extends PHPUnit_Framework_TestCase
         $message = new Zend_Mail_Message(array('file' => $this->_file));
         $message->setPartClass('ZF3745_Mail_Part');
         $this->assertEquals('ZF3745_Mail_Part', $message->getPartClass());
-        
+
         // Ensure message parts use the specified part class
         $this->assertGreaterThan(0, count($message));
         foreach ( $message as $part ) {
@@ -529,7 +529,7 @@ class Zend_Mail_MessageTest extends PHPUnit_Framework_TestCase
             'multi-value' => array('Fake', array('okay', "foo-bar\r\n\r\nevilContent")),
         );
     }
-    
+
     /**
      * @dataProvider invalidHeaders
      * @group ZF2015-04

--- a/tests/Zend/Queue/Stomp/ClientTest.php
+++ b/tests/Zend/Queue/Stomp/ClientTest.php
@@ -54,7 +54,7 @@ class Zend_Queue_Stomp_Connection_Mock
      * @param array $config ('scheme', 'host', 'port')
      * @return true;
      */
-    public function open($scheme, $host, $port)
+    public function open($scheme, $host, $port, array $options = array())
     {
         if ( $port == 0 )  return false;
         return true;

--- a/tests/Zend/Session/SessionTest.php
+++ b/tests/Zend/Session/SessionTest.php
@@ -71,7 +71,7 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
     /**
      * Set up tests environment
      */
-    function setUp()
+    public function setUp()
     {
         // _unitTestEnabled is utilised by other tests to handle session data processing
         // Zend_Session tests should pass with _unitTestEnabled turned off
@@ -85,7 +85,8 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
      */
     public function tearDown()
     {
-        ini_set('session.save_path', $this->_savePath);
+        session_abort();
+        session_save_path($this->_savePath);
 
         $this->assertSame(
             E_ALL | E_STRICT,
@@ -104,6 +105,9 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
                 return;
             }
         }
+
+        Zend_Session::$_unitTestEnabled = true;
+        Zend_Session::destroy();
     }
 
     /**
@@ -1085,6 +1089,8 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
         if ( !is_dir($sessionStore) ) @mkdir($sessionStore, 0755, true);
         ini_set('session.save_path', "1;666;" . $sessionStore);
 
+        session_start();
+
         // When using subdirs for session.save_path, the directory structure
         // is your own responsibility...set it up, or else bad things happen
         foreach ( $sessionCharSet as $subdir ) {
@@ -1107,7 +1113,7 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
 
         // We don't need the session any more, clean it up
         //but we don't to want to destroy it completely, while other tests can start
-        Zend_Session::$_unitTestEnabled = true; 
+        Zend_Session::$_unitTestEnabled = true;
         Zend_Session::destroy();
         foreach ( $sessionCharSet as $subdir ) {
             @rmdir($sessionStore . DIRECTORY_SEPARATOR . $subdir);

--- a/tests/Zend/Session/SessionTest.php
+++ b/tests/Zend/Session/SessionTest.php
@@ -1089,13 +1089,13 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
         if ( !is_dir($sessionStore) ) @mkdir($sessionStore, 0755, true);
         ini_set('session.save_path', "1;666;" . $sessionStore);
 
-        session_start();
-
         // When using subdirs for session.save_path, the directory structure
         // is your own responsibility...set it up, or else bad things happen
         foreach ( $sessionCharSet as $subdir ) {
             @mkdir($sessionStore . DIRECTORY_SEPARATOR . $subdir);
         }
+
+        session_start();
 
         // Set session ID to invalid value
         session_id('xxx');

--- a/tests/Zend/TranslateTest.php
+++ b/tests/Zend/TranslateTest.php
@@ -637,7 +637,7 @@ class Zend_TranslateTest extends PHPUnit_Framework_TestCase
     public function testEmptyTranslation()
     {
         $lang = new Zend_Translate(Zend_Translate::AN_ARRAY, null, null, array('disableNotices' => true));
-        $this->assertEquals(0, count($lang->getList()));
+        $this->assertNull($lang->getList());
     }
 
     /**

--- a/tests/Zend/View/Helper/Navigation/_files/mvc/views/bc.phtml
+++ b/tests/Zend/View/Helper/Navigation/_files/mvc/views/bc.phtml
@@ -1,4 +1,4 @@
 <?php
 echo implode(', ', array_map(
-        create_function('$a', 'return $a->getLabel();'),
+        function ($a) { return $a->getLabel(); },
         $this->pages));

--- a/tests/Zend/View/Helper/PartialLoopTest.php
+++ b/tests/Zend/View/Helper/PartialLoopTest.php
@@ -402,7 +402,7 @@ class Zend_View_Helper_PartialLoopTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class Zend_View_Helper_PartialLoop_IteratorTest implements Iterator
+class Zend_View_Helper_PartialLoop_IteratorTest implements Iterator, Countable
 {
     public $items;
 
@@ -440,9 +440,14 @@ class Zend_View_Helper_PartialLoop_IteratorTest implements Iterator
     {
         return $this->items;
     }
+
+    public function count()
+    {
+        return count($this->items);
+    }
 }
 
-class Zend_View_Helper_PartialLoop_RecursiveIteratorTest implements Iterator
+class Zend_View_Helper_PartialLoop_RecursiveIteratorTest implements Iterator, Countable
 {
     public $items;
 
@@ -481,6 +486,11 @@ class Zend_View_Helper_PartialLoop_RecursiveIteratorTest implements Iterator
     {
         return (current($this->items) !== false);
     }
+
+    public function count()
+    {
+        return count($this->items);
+    }
 }
 
 class Zend_View_Helper_PartialLoop_BogusIteratorTest
@@ -500,7 +510,7 @@ class Zend_View_Helper_PartialLoop_ToArrayTest
     }
 }
 
-class Zend_View_Helper_PartialLoop_IteratorWithToArrayTest implements Iterator
+class Zend_View_Helper_PartialLoop_IteratorWithToArrayTest implements Iterator, Countable
 {
     public $items;
 
@@ -537,6 +547,11 @@ class Zend_View_Helper_PartialLoop_IteratorWithToArrayTest implements Iterator
     public function valid()
     {
         return (current($this->items) !== false);
+    }
+
+    public function count()
+    {
+        return count($this->items);
     }
 }
 

--- a/tests/Zend/XmlRpc/RequestTest.php
+++ b/tests/Zend/XmlRpc/RequestTest.php
@@ -288,14 +288,14 @@ class Zend_XmlRpc_RequestTest extends PHPUnit_Framework_TestCase
 
         $result = $sx->xpath('//methodName');
         $count = 0;
-        while (list( , $node) = each($result)) {
+        foreach ($result as $node) {
             ++$count;
         }
         $this->assertEquals(1, $count, $xml);
 
         $result = $sx->xpath('//params');
         $count = 0;
-        while (list( , $node) = each($result)) {
+        foreach ($result as $node) {
             ++$count;
         }
         $this->assertEquals(1, $count, $xml);


### PR DESCRIPTION
This removes any cases of `each()` from ZF for PHP 7.2 compatibility.

Most of the changes come from `Bukashk0zzz:php-7.2` branch, but then modified to make tests pass (a couple of the changes modified behavior of the code, causing a few tests to fail).

This PR should replace #9.

All tests pass on my local machine, curious how travis will do, especially the 7.2 run.