### PR TITLE
stop blindly including files

### DIFF
--- a/library/Zend/Loader.php
+++ b/library/Zend/Loader.php
@@ -130,10 +130,13 @@ class Zend_Loader
         /**
          * Try finding for the plain filename in the include_path.
          */
-        if ($once) {
-            include_once $filename;
-        } else {
-            include $filename;
+        $absPath = stream_resolve_include_path($filename);
+        if ($absPath !== false) {
+            if ($once) {
+                include_once $absPath;
+            } else {
+                include $absPath;
+            }
         }
 
         /**
@@ -308,10 +311,13 @@ class Zend_Loader
      */
     protected static function _includeFile($filespec, $once = false)
     {
-        if ($once) {
-            return include_once $filespec;
-        } else {
-            return include $filespec ;
+        $absPath = stream_resolve_include_path($filespec);
+        if ($absPath !== false) {
+            if ($once) {
+                return include_once $absPath;
+            } else {
+                return include $absPath;
+            }
         }
     }
 

--- a/tests/Zend/Barcode/FactoryTest.php
+++ b/tests/Zend/Barcode/FactoryTest.php
@@ -239,7 +239,8 @@ class Zend_Barcode_FactoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Exception
+     * @expectedExceptionMessage does not exist or class "Zend_Barcode_Object_Zf123" was not found in the file
      */
     public function testBarcodeObjectFactoryWithUnexistantBarcode()
     {
@@ -338,7 +339,8 @@ class Zend_Barcode_FactoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Exception
+     * @expectedExceptionMessage does not exist or class "Zend_Barcode_Renderer_Zend" was not found in the file
      */
     public function testBarcodeRendererFactoryWithUnexistantRenderer()
     {

--- a/tests/Zend/Db/Adapter/StaticTest.php
+++ b/tests/Zend/Db/Adapter/StaticTest.php
@@ -342,7 +342,8 @@ class Zend_Db_Adapter_StaticTest extends PHPUnit_Framework_TestCase
                 );
         } catch (Exception $e) {
             set_include_path($oldIncludePath);
-            $this->assertContains('failed to open stream', $e->getMessage());
+            $this->assertInstanceOf('Zend_Exception', $e);
+            $this->assertContains('does not exist or class "Test_MyCompany2_Dbadapter" was not found in the file', $e->getMessage());
             return;
         }
 

--- a/tests/Zend/Db/Table/Relationships/TestCommon.php
+++ b/tests/Zend/Db/Table/Relationships/TestCommon.php
@@ -158,7 +158,8 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Exception
+     * @expectedExceptionMessage does not exist or class "nonexistant_class" was not found in the file
      */
     public function testTableRelationshipFindParentRowErrorOnBadString()
     {
@@ -265,7 +266,8 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Exception
+     * @expectedExceptionMessage does not exist or class "nonexistant_class" was not found in the file
      */
     public function testTableRelationshipFindManyToManyRowsetErrorOnBadClassNameAsString()
     {
@@ -280,7 +282,8 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Exception
+     * @expectedExceptionMessage does not exist or class "nonexistant_class" was not found in the file
      */
     public function testTableRelationshipFindManyToManyRowsetErrorOnBadClassNameAsStringForIntersection()
     {
@@ -425,7 +428,8 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Exception
+     * @expectedExceptionMessage does not exist or class "nonexistant_class" was not found in the file
      */
     public function testTableRelationshipFindDependentRowsetPhpError()
     {

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -30,6 +30,12 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
 require_once 'Zend/Loader/AutoloaderFactory.php';
 require_once 'Zend/Loader/ClassMapAutoloader.php';
 require_once 'Zend/Loader/StandardAutoloader.php';
+// Trigger autoloader for these
+class_exists('PHPUnit_Framework_Constraint_IsNull');
+class_exists('PHPUnit_Framework_Constraint_IsTrue');
+class_exists('SebastianBergmann\Exporter\Exporter');
+class_exists('PHPUnit_Framework_Constraint_IsEqual');
+class_exists('PHPUnit_Framework_Constraint_Exception');
 
 /**
  * @package    Zend_Loader

--- a/tests/Zend/Loader/AutoloaderTest.php
+++ b/tests/Zend/Loader/AutoloaderTest.php
@@ -340,15 +340,28 @@ class Zend_Loader_AutoloaderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(class_exists('ZendLoaderAutoloader_Foo', false));
     }
 
-    public function testAutoloadShouldNotSuppressFileNotFoundWarningsWhenFlagIsDisabled()
+    public function testAutoloadShouldNotSuppressParseErrorWhenSuppressNotFoundWarningsFlagIsDisabled()
     {
         $this->addTestIncludePath();
         $this->autoloader->suppressNotFoundWarnings(false);
         $this->autoloader->registerNamespace('ZendLoaderAutoloader');
+        try {
+            $this->assertFalse(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_ZFAutoloadParseError'));
+        } catch (ParseError $e) {
+        }
+
+        $this->assertInstanceOf('ParseError', $e);
+    }
+
+    public function testAutoloadShouldSuppressParseErrorWhenSuppressNotFoundWarningsFlagIsEnabled()
+    {
+        $this->addTestIncludePath();
+        $this->autoloader->suppressNotFoundWarnings(true);
+        $this->autoloader->registerNamespace('ZendLoaderAutoloader');
         set_error_handler(array($this, 'handleErrors'));
-        $this->assertFalse(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_Bar'));
+        $this->assertFalse(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_ZFAutoloadParseError'));
         restore_error_handler();
-        $this->assertNotNull($this->error);
+        $this->assertNull($this->error);
     }
 
     public function testAutoloadShouldReturnTrueIfFunctionBasedAutoloaderMatchesAndReturnsNonFalseValue()

--- a/tests/Zend/Loader/AutoloaderTest.php
+++ b/tests/Zend/Loader/AutoloaderTest.php
@@ -342,6 +342,10 @@ class Zend_Loader_AutoloaderTest extends PHPUnit_Framework_TestCase
 
     public function testAutoloadShouldNotSuppressParseErrorWhenSuppressNotFoundWarningsFlagIsDisabled()
     {
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped(__METHOD__ . ' requires PHP version 7.0.0 or greater');
+        }
+
         $this->addTestIncludePath();
         $this->autoloader->suppressNotFoundWarnings(false);
         $this->autoloader->registerNamespace('ZendLoaderAutoloader');
@@ -355,13 +359,13 @@ class Zend_Loader_AutoloaderTest extends PHPUnit_Framework_TestCase
 
     public function testAutoloadShouldSuppressParseErrorWhenSuppressNotFoundWarningsFlagIsEnabled()
     {
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped(__METHOD__ . ' requires PHP version 7.0.0 or greater');
+        }
         $this->addTestIncludePath();
         $this->autoloader->suppressNotFoundWarnings(true);
         $this->autoloader->registerNamespace('ZendLoaderAutoloader');
-        set_error_handler(array($this, 'handleErrors'));
         $this->assertFalse(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_ZFAutoloadParseError'));
-        restore_error_handler();
-        $this->assertNull($this->error);
     }
 
     public function testAutoloadShouldReturnTrueIfFunctionBasedAutoloaderMatchesAndReturnsNonFalseValue()

--- a/tests/Zend/Loader/_files/ZendLoaderAutoloader/ZFAutoloadParseError.php
+++ b/tests/Zend/Loader/_files/ZendLoaderAutoloader/ZFAutoloadParseError.php
@@ -29,7 +29,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class ParseError
+class ZendLoaderAutoloader_ZFAutoloadParseError
 {
     parseError;
 }

--- a/tests/Zend/LoaderTest.php
+++ b/tests/Zend/LoaderTest.php
@@ -542,34 +542,6 @@ class Zend_LoaderTest extends PHPUnit_Framework_TestCase
         $path = 'C:/this/file/should/not/exist.php';
         $this->assertFalse(Zend_Loader::isReadable($path));
     }
-
-    /**
-     * In order to play nice with spl_autoload, an autoload callback should
-     * *not* emit errors (exceptions are okay). ZF-2923 requests that this
-     * behavior be applied, which counters the previous request in ZF-2463.
-     *
-     * As it is, the new behavior *will* hide parse and other errors. However,
-     * a fatal error *will* be raised in such situations, which is as
-     * appropriate or more appropriate than raising an exception.
-     *
-     * NOTE: Removed from test suite, as autoload functionality in Zend_Loader
-     * is now deprecated.
-     *
-     * @see    http://framework.zend.com/issues/browse/ZF-2463
-     * @group  ZF-2923
-     * @return void
-    public function testLoaderAutoloadShouldHideParseError()
-    {
-        if (isset($_SERVER['OS'])  &&  strstr($_SERVER['OS'], 'Win')) {
-            $this->markTestSkipped(__METHOD__ . ' does not work on Windows');
-        }
-        $command = 'php -d include_path='
-            . escapeshellarg(get_include_path())
-            . ' Zend/Loader/AutoloadDoesNotHideParseError.php 2>&1';
-        $output = shell_exec($command);
-        $this->assertTrue(empty($output));
-    }
-     */
 }
 
 // Call Zend_LoaderTest::main() if this source file is executed directly.


### PR DESCRIPTION
Zend_Loader will now check for the existence of a file prior to including it. This prevents Warnings from being thrown every time the autoloader is called on a file that doesn't exist.

The code is already set up such that a Zend_Exception will be thrown if the file isn't successfully loaded. However, a number of the tests were expecting a PHPUnit_Framework_Error because of the PHP warning that was generated before this, so these have been updated to look for the exception instead.

Some backstory - I run into this when doing a number of things, but most notably when running PHPUnit tests, which does blacklist checks against a number of classes, using `class_exists` calls. If these classes don't exist, it throws warnings. Because of this, we tend to needlessly include other projects in our composer dependencies just so the blacklist checking can find them when it looks for them.

There's an old (rejected) github issue about this and the ZF1 autoloader: https://github.com/sebastianbergmann/phpunit/issues/1207

