### PR TITLE
rename project, update PHP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zendframework/zendframework1",
+    "name": "diablomedia/zendframework1",
     "description": "Zend Framework 1",
     "type": "library",
     "keywords": [
@@ -9,7 +9,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.2.11"
+        "php": ">=5.6.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Rename project to diablomedia/zendframework1 so we can start tagging releases.

This WILL break any projects that currently depend on this repository being named zendframework/zendframework1@dev-master.