### PR TITLE
Fixing a PHP 7.2 warning in Zend_Validate_File_Upload

### DIFF
--- a/library/Zend/Validate/File/Upload.php
+++ b/library/Zend/Validate/File/Upload.php
@@ -161,7 +161,9 @@ class Zend_Validate_File_Upload extends Zend_Validate_Abstract
      */
     public function isValid($value, $file = null)
     {
-        $this->_messages = null;
+        $this->_messages = array();
+        $files = array();
+
         if (array_key_exists($value, $this->_files)) {
             $files[$value] = $this->_files[$value];
         } else {


### PR DESCRIPTION
For some reason `$this->_messages` was being set to `null` at the top of this method, but then being counted later.

All instances of this property in the parent class (`Zend_Validate_Abstract`) are `array`, never `null`.  Keeping this as an empty array here keeps the type the same, and prevents the countable warning.

I also initialized the `$files` variable as an array as well. It’s only used locally.

I tried to write a quick test to cover this change (would have to be a valid file upload) but because `is_uploaded_file` is used to check if the file was really an upload, it’s not easy to test this.