### PR TITLE
Using stubs to better analyze some components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+Zend Framework 1
+================
+[![Build Status](https://travis-ci.org/diablomedia/zf1.svg?branch=version-test-fix)](https://travis-ci.org/diablomedia/zf1)
+[![codecov](https://codecov.io/gh/diablomedia/zf1/branch/master/graph/badge.svg)](https://codecov.io/gh/diablomedia/zf1)
+[![Latest Stable Version](https://poser.pugx.org/diablomedia/zendframework1/v/stable)](https://packagist.org/packages/diablomedia/zendframework1)
+[![Total Downloads](https://poser.pugx.org/diablomedia/zendframework1/downloads)](https://packagist.org/packages/diablomedia/zendframework1)
+[![License](https://poser.pugx.org/diablomedia/zendframework1/license)](https://packagist.org/packages/diablomedia/zendframework1)
+
+This is a fork of Zend Framework 1 that we'll maintain as long as we're using it, mainly just to keep it working on new versions of PHP as they're released.
+
+This fork is based on the final release of the original project (version 1.12.20), and releases will follow [semantic versioning](https://semver.org/). The first release of this fork is version 2.0.0.
+
+## Release Highlights
+
+### 3.0.0
+
+* Minimum PHP version set to 7.0
+* PHPUnit upgraded to 6.0
+
+### 2.0.0
+
+* Renamed to our organization in Composer
+* Minimum PHP version set to 5.6
+
+## The following is the original README contents from upstream:
+
 ![Logo](http://framework.zend.com/images/logos/ZendFramework-logo.png)
 
 > ## End-of-Life occurs 28 Sep 2016
@@ -9,13 +35,6 @@
 >
 > - https://framework.zend.com/blog/2016-06-28-zf1-eol.html
 
----
-
-[![Build Status](https://travis-ci.org/diablomedia/zf1.svg?branch=version-test-fix)](https://travis-ci.org/diablomedia/zf1)
-[![codecov](https://codecov.io/gh/diablomedia/zf1/branch/master/graph/badge.svg)](https://codecov.io/gh/diablomedia/zf1)
-[![Latest Stable Version](https://poser.pugx.org/diablomedia/zendframework1/v/stable)](https://packagist.org/packages/diablomedia/zendframework1)
-[![Total Downloads](https://poser.pugx.org/diablomedia/zendframework1/downloads)](https://packagist.org/packages/diablomedia/zendframework1)
-[![License](https://poser.pugx.org/diablomedia/zendframework1/license)](https://packagist.org/packages/diablomedia/zendframework1)
 
 RELEASE INFORMATION
 ===================

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     "repositories": [
         {
             "type": "vcs",
+            "no-api": true,
             "url": "https://github.com/diablomedia/phpstorm-stubs"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,8 @@
     ],
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": ">=7.0.0"
     },
@@ -32,11 +34,19 @@
     "config": {
         "bin-dir": "bin"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/diablomedia/phpstorm-stubs"
+        }
+    ],
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "phpunit/dbunit": "^3.0.2",
         "phpunit/phpcov": "^4.0",
-        "phpstan/phpstan": "^0.9.2"
+        "phpstan/phpstan": "^0.9.2",
+        "jetbrains/phpstorm-stubs": "dev-phpstan",
+        "pear/archive_tar": "^1.4"
     },
     "archive": {
         "exclude": ["/demos", "/documentation", "/tests"]

--- a/library/Zend/Amf/Value/MessageBody.php
+++ b/library/Zend/Amf/Value/MessageBody.php
@@ -107,7 +107,7 @@ class Zend_Amf_Value_MessageBody
      * Set target Uri
      *
      * @param  string $targetUri
-     * @return Zend_Amf_Value_MessageBody
+     * @return $this
      */
     public function setTargetUri($targetUri)
     {
@@ -132,7 +132,7 @@ class Zend_Amf_Value_MessageBody
      * Set response Uri
      *
      * @param  string $responseUri
-     * @return Zend_Amf_Value_MessageBody
+     * @return $this
      */
     public function setResponseUri($responseUri)
     {
@@ -157,7 +157,7 @@ class Zend_Amf_Value_MessageBody
      * Set response data
      *
      * @param  mixed $data
-     * @return Zend_Amf_Value_MessageBody
+     * @return $this
      */
     public function setData($data)
     {
@@ -169,7 +169,7 @@ class Zend_Amf_Value_MessageBody
      * Set reply method
      *
      * @param  string $methodName
-     * @return Zend_Amf_Value_MessageBody
+     * @return $this
      */
     public function setReplyMethod($methodName)
     {

--- a/library/Zend/Cache/Backend/Apc.php
+++ b/library/Zend/Cache/Backend/Apc.php
@@ -98,6 +98,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
     public function save($data, $id, $tags = array(), $specificLifetime = false)
     {
         $lifetime = $this->getLifetime($specificLifetime);
+        /** @var bool $result Won't return an array if $id is a string */
         $result = apc_store($id, array($data, time(), $lifetime), $lifetime);
         if (count($tags) > 0) {
             $this->_log(self::TAGS_UNSUPPORTED_BY_SAVE_OF_APC_BACKEND);

--- a/library/Zend/Cache/Backend/Sqlite.php
+++ b/library/Zend/Cache/Backend/Sqlite.php
@@ -53,9 +53,9 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
     /**
      * DB ressource
      *
-     * @var mixed $_db
+     * @var resource $_db
      */
-    private $_db = null;
+    private $_db;
 
     /**
      * Boolean to store if the structure has benn checked or not
@@ -481,10 +481,12 @@ class Zend_Cache_Backend_Sqlite extends Zend_Cache_Backend implements Zend_Cache
         if (is_resource($this->_db)) {
             return $this->_db;
         } else {
-            $this->_db = @sqlite_open($this->_options['cache_db_complete_path']);
-            if (!(is_resource($this->_db))) {
+            $db = @sqlite_open($this->_options['cache_db_complete_path']);
+            if (!(is_resource($db))) {
                 Zend_Cache::throwException("Impossible to open " . $this->_options['cache_db_complete_path'] . " cache DB file");
             }
+            $this->_db = $db;
+
             return $this->_db;
         }
     }

--- a/library/Zend/Cloud/QueueService/Adapter/WindowsAzure.php
+++ b/library/Zend/Cloud/QueueService/Adapter/WindowsAzure.php
@@ -87,10 +87,10 @@ class Zend_Cloud_QueueService_Adapter_WindowsAzure
             $host = $options[self::HOST];
         }
         if (! isset($options[self::ACCOUNT_NAME])) {
-            throw new Zend_Cloud_Storage_Exception('No Windows Azure account name provided.');
+            throw new Zend_Cloud_QueueService_Exception('No Windows Azure account name provided.');
         }
         if (! isset($options[self::ACCOUNT_KEY])) {
-            throw new Zend_Cloud_Storage_Exception('No Windows Azure account key provided.');
+            throw new Zend_Cloud_QueueService_Exception('No Windows Azure account key provided.');
         }
         try {
             // TODO: support $usePathStyleUri and $retryPolicy

--- a/library/Zend/Controller/Action/Helper/Abstract.php
+++ b/library/Zend/Controller/Action/Helper/Abstract.php
@@ -32,7 +32,7 @@ abstract class Zend_Controller_Action_Helper_Abstract
     /**
      * $_actionController
      *
-     * @var Zend_Controller_Action $_actionController
+     * @var Zend_Controller_Action|null $_actionController
      */
     protected $_actionController = null;
 
@@ -56,7 +56,7 @@ abstract class Zend_Controller_Action_Helper_Abstract
     /**
      * Retrieve current action controller
      *
-     * @return Zend_Controller_Action
+     * @return Zend_Controller_Action|null
      */
     public function getActionController()
     {

--- a/library/Zend/Controller/Action/HelperBroker.php
+++ b/library/Zend/Controller/Action/HelperBroker.php
@@ -37,7 +37,7 @@ class Zend_Controller_Action_HelperBroker
     protected $_actionController;
 
     /**
-     * @var Zend_Loader_PluginLoader_Interface
+     * @var Zend_Loader_PluginLoader_Interface|null
      */
     protected static $_pluginLoader;
 
@@ -51,7 +51,7 @@ class Zend_Controller_Action_HelperBroker
     /**
      * Set PluginLoader for use with broker
      *
-     * @param  Zend_Loader_PluginLoader_Interface $loader
+     * @param  Zend_Loader_PluginLoader_Interface|null $loader
      * @return void
      */
     public static function setPluginLoader($loader)

--- a/library/Zend/Controller/Request/Http.php
+++ b/library/Zend/Controller/Request/Http.php
@@ -236,7 +236,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      *
      * @param  string|array $spec
      * @param  null|mixed $value
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setQuery($spec, $value = null)
     {
@@ -277,7 +277,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      *
      * @param  string|array $spec
      * @param  null|mixed $value
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setPost($spec, $value = null)
     {
@@ -375,7 +375,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * $_SERVER['HTTP_X_REWRITE_URL'], or $_SERVER['ORIG_PATH_INFO'] + $_SERVER['QUERY_STRING'].
      *
      * @param string $requestUri
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setRequestUri($requestUri = null)
     {
@@ -458,7 +458,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * ORIG_SCRIPT_NAME in its determination.
      *
      * @param mixed $baseUrl
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setBaseUrl($baseUrl = null)
     {
@@ -552,7 +552,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * Set the base path for the URL
      *
      * @param string|null $basePath
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setBasePath($basePath = null)
     {
@@ -601,7 +601,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * Set the PATH_INFO string
      *
      * @param string|null $pathInfo
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setPathInfo($pathInfo = null)
     {
@@ -661,7 +661,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * Can be empty array, or contain one or more of '_GET' or '_POST'.
      *
      * @param  array $paramSources
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setParamSources(array $paramSources = array())
     {
@@ -687,7 +687,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      *
      * @param mixed $key
      * @param mixed $value
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setParam($key, $value)
     {
@@ -760,7 +760,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * using the keys specified in the array.
      *
      * @param array $params
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setParams(array $params)
     {
@@ -778,7 +778,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      *
      * @param string $name
      * @param string $target
-     * @return Zend_Controller_Request_Http
+     * @return $this
      */
     public function setAlias($name, $target)
     {

--- a/library/Zend/Crypt.php
+++ b/library/Zend/Crypt.php
@@ -135,7 +135,7 @@ class Zend_Crypt
      * @param string $algorithm
      * @param string $data
      * @param bool $binaryOutput
-     * @return string
+     * @return string|false
      */
     protected static function _digestMhash($algorithm, $data, $binaryOutput)
     {

--- a/library/Zend/Crypt/Hmac.php
+++ b/library/Zend/Crypt/Hmac.php
@@ -81,7 +81,7 @@ class Zend_Crypt_Hmac extends Zend_Crypt
      * @param string $data
      * @param string $output
      * @throws Zend_Crypt_Hmac_Exception
-     * @return string
+     * @return string|false
      */
     public static function compute($key, $hash, $data, $output = self::STRING)
     {
@@ -134,7 +134,7 @@ class Zend_Crypt_Hmac extends Zend_Crypt
      * @param string $data
      * @param string $output
      * @param bool $internal Option to not use hash() functions for testing
-     * @return string
+     * @return string|false
      */
     protected static function _hash($data, $output = self::STRING, $internal = false)
     {

--- a/library/Zend/Crypt/Math/BigInteger/Gmp.php
+++ b/library/Zend/Crypt/Math/BigInteger/Gmp.php
@@ -78,7 +78,7 @@ class Zend_Crypt_Math_BigInteger_Gmp implements Zend_Crypt_Math_BigInteger_Inter
      *
      * @param resource $left_operand
      * @param resource $right_operand
-     * @return int
+     * @return string
      */
     public function compare($left_operand, $right_operand)
     {

--- a/library/Zend/Date.php
+++ b/library/Zend/Date.php
@@ -1277,7 +1277,7 @@ class Zend_Date extends Zend_Date_DateObject
      * @param  string                          $calc    Calculation to make, one of: 'add'|'sub'|'cmp'|'copy'|'set'
      * @param  string|integer|array|Zend_Date  $date    Date or datepart to calculate with
      * @param  string                          $part    Part of the date to calculate, if null the timestamp is used
-     * @param  string|Zend_Locale              $locale  Locale for parsing input
+     * @param  string|Zend_Locale|null              $locale  Locale for parsing input
      * @return integer|string|Zend_Date        new timestamp
      * @throws Zend_Date_Exception
      */
@@ -2705,7 +2705,7 @@ class Zend_Date extends Zend_Date_DateObject
      * @param  string                    $calc    Calculation to make
      * @param  string|integer|array|Zend_Date  $time    Time to calculate with, if null the actual time is taken
      * @param  string                          $format  Timeformat for parsing input
-     * @param  string|Zend_Locale              $locale  Locale for parsing input
+     * @param  string|Zend_Locale|null              $locale  Locale for parsing input
      * @return integer|$this  new time
      * @throws Zend_Date_Exception
      */
@@ -2865,7 +2865,7 @@ class Zend_Date extends Zend_Date_DateObject
      * @param  string                          $calc    Calculation to make
      * @param  string|integer|array|Zend_Date  $date    Date to calculate with, if null the actual date is taken
      * @param  string                          $format  Date format for parsing
-     * @param  string|Zend_Locale              $locale  Locale for parsing input
+     * @param  string|Zend_Locale|null         $locale  Locale for parsing input
      * @return integer|$this  new date
      * @throws Zend_Date_Exception
      */
@@ -3438,7 +3438,7 @@ class Zend_Date extends Zend_Date_DateObject
      * @param  string|integer|Zend_Date|array $value  Datevalue to calculate with, if null the actual value is taken
      * @param  string                   $type
      * @param  string                   $parameter
-     * @param  string|Zend_Locale       $locale Locale for parsing input
+     * @param  string|Zend_Locale|null  $locale Locale for parsing input
      * @throws Zend_Date_Exception
      * @return integer|$this  new date
      */
@@ -3584,7 +3584,7 @@ class Zend_Date extends Zend_Date_DateObject
      *
      * @param  string                          $calc    Calculation to make
      * @param  string|integer|array|Zend_Date  $month   Month to calculate with, if null the actual month is taken
-     * @param  string|Zend_Locale              $locale  Locale for parsing input
+     * @param  string|Zend_Locale|null         $locale  Locale for parsing input
      * @return integer|$this  new time
      * @throws Zend_Date_Exception
      */
@@ -3735,9 +3735,9 @@ class Zend_Date extends Zend_Date_DateObject
     /**
      * Returns the calculated day
      *
-     * @param string      $calc   Type of calculation to make
-     * @param Zend_Date   $day    Day to calculate, when null the actual day is calculated
-     * @param Zend_Locale $locale Locale for parsing input
+     * @param string           $calc   Type of calculation to make
+     * @param Zend_Date        $day    Day to calculate, when null the actual day is calculated
+     * @param Zend_Locale|null $locale Locale for parsing input
      * @throws Zend_Date_Exception
      * @return $this|integer
      */
@@ -3884,9 +3884,9 @@ class Zend_Date extends Zend_Date_DateObject
     /**
      * Returns the calculated weekday
      *
-     * @param  string      $calc     Type of calculation to make
-     * @param  Zend_Date   $weekday  Weekday to calculate, when null the actual weekday is calculated
-     * @param  Zend_Locale $locale   Locale for parsing input
+     * @param  string           $calc     Type of calculation to make
+     * @param  Zend_Date        $weekday  Weekday to calculate, when null the actual weekday is calculated
+     * @param  Zend_Locale|null $locale   Locale for parsing input
      * @return $this|integer
      * @throws Zend_Date_Exception
      */

--- a/library/Zend/Db/Adapter/Sqlsrv.php
+++ b/library/Zend/Db/Adapter/Sqlsrv.php
@@ -144,11 +144,13 @@ class Zend_Db_Adapter_Sqlsrv extends Zend_Db_Adapter_Abstract
             }
         }
 
-        $this->_connection = sqlsrv_connect($serverName, $connectionInfo);
+        $connection = sqlsrv_connect($serverName, $connectionInfo);
 
-        if (!$this->_connection) {
+        if (!$connection) {
             throw new Zend_Db_Adapter_Sqlsrv_Exception(sqlsrv_errors());
         }
+
+        $this->_connection = $connection;
     }
 
     /**

--- a/library/Zend/Db/Statement/Db2.php
+++ b/library/Zend/Db/Statement/Db2.php
@@ -54,14 +54,16 @@ class Zend_Db_Statement_Db2 extends Zend_Db_Statement
 
         // db2_prepare on i5 emits errors, these need to be
         // suppressed so that proper exceptions can be thrown
-        $this->_stmt = @db2_prepare($connection, $sql);
+        $stmt = @db2_prepare($connection, $sql);
 
-        if (!$this->_stmt) {
+        if (!$stmt) {
             throw new Zend_Db_Statement_Db2_Exception(
                 db2_stmt_errormsg(),
                 db2_stmt_error()
             );
         }
+
+        $this->_stmt = $stmt;
     }
 
     /**

--- a/library/Zend/Db/Statement/Oracle.php
+++ b/library/Zend/Db/Statement/Oracle.php
@@ -82,10 +82,12 @@ class Zend_Db_Statement_Oracle extends Zend_Db_Statement
     protected function _prepare($sql)
     {
         $connection = $this->_adapter->getConnection();
-        $this->_stmt = @oci_parse($connection, $sql);
-        if (!$this->_stmt) {
+        $stmt = @oci_parse($connection, $sql);
+        if (!$stmt) {
             throw new Zend_Db_Statement_Oracle_Exception(oci_error($connection));
         }
+
+        $this->_stmt = $stmt;
     }
 
     /**

--- a/library/Zend/Db/Statement/Sqlsrv.php
+++ b/library/Zend/Db/Statement/Sqlsrv.php
@@ -58,11 +58,13 @@ class Zend_Db_Statement_Sqlsrv extends Zend_Db_Statement
     {
         $connection = $this->_adapter->getConnection();
 
-        $this->_stmt = sqlsrv_prepare($connection, $sql);
+        $stmt = sqlsrv_prepare($connection, $sql);
 
-        if (!$this->_stmt) {
+        if (!$stmt) {
             throw new Zend_Db_Statement_Sqlsrv_Exception(sqlsrv_errors());
         }
+
+        $this->_stmt = $stmt;
 
         $this->_originalSQL = $sql;
     }
@@ -104,7 +106,7 @@ class Zend_Db_Statement_Sqlsrv extends Zend_Db_Statement
      * Returns the number of columns in the result set.
      * Returns null if the statement has no result set metadata.
      *
-     * @return int The number of columns.
+     * @return int|false The number of columns.
      */
     public function columnCount()
     {
@@ -193,11 +195,13 @@ class Zend_Db_Statement_Sqlsrv extends Zend_Db_Statement
             $params = $params_;
         }
 
-        $this->_stmt = sqlsrv_query($connection, $this->_originalSQL, $params);
+        $stmt = sqlsrv_query($connection, $this->_originalSQL, $params);
 
-        if (!$this->_stmt) {
+        if (!$stmt) {
             throw new Zend_Db_Statement_Sqlsrv_Exception(sqlsrv_errors());
         }
+
+        $this->_stmt = $stmt;
 
         $this->_executed = true;
 

--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -83,7 +83,7 @@ class Zend_Dom_Query
      * Set document encoding
      *
      * @param  string $encoding
-     * @return Zend_Dom_Query
+     * @return $this
      */
     public function setEncoding($encoding)
     {
@@ -106,7 +106,7 @@ class Zend_Dom_Query
      *
      * @param  string|DOMDocument $document
      * @param  null|string $encoding Document encoding
-     * @return Zend_Dom_Query
+     * @return $this
      */
     public function setDocument($document, $encoding = null)
     {
@@ -134,7 +134,7 @@ class Zend_Dom_Query
      * Set DOMDocument to query
      *
      * @param  DOMDocument $document
-     * @return Zend_Dom_Query
+     * @return $this
      */
     public function setDocumentDom(DOMDocument $document)
     {
@@ -151,7 +151,7 @@ class Zend_Dom_Query
      *
      * @param  string $document
      * @param  null|string $encoding Document encoding
-     * @return Zend_Dom_Query
+     * @return $this
      */
     public function setDocumentHtml($document, $encoding = null)
     {
@@ -168,7 +168,7 @@ class Zend_Dom_Query
      *
      * @param  string $document
      * @param  null|string $encoding Document encoding
-     * @return Zend_Dom_Query
+     * @return $this
      */
     public function setDocumentXhtml($document, $encoding = null)
     {
@@ -185,7 +185,7 @@ class Zend_Dom_Query
      *
      * @param  string $document
      * @param  null|string $encoding Document encoding
-     * @return Zend_Dom_Query
+     * @return $this
      */
     public function setDocumentXml($document, $encoding = null)
     {

--- a/library/Zend/File/ClassFileLocator.php
+++ b/library/Zend/File/ClassFileLocator.php
@@ -153,7 +153,7 @@ class Zend_File_ClassFileLocator extends FilterIterator
                                     $namespace = $savedNamespace;
                                 } else {
                                     $namespace = null;
-                    }
+                                }
 
                             }
                             $class = (null === $namespace) ? $content : $namespace . '\\' . $content;

--- a/library/Zend/File/Transfer/Adapter/Abstract.php
+++ b/library/Zend/File/Transfer/Adapter/Abstract.php
@@ -1433,7 +1433,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
     /**
      * Returns found files based on internal file array and given files
      *
-     * @param  string|array $files       (Optional) Files to return
+     * @param  string|array|null $files       (Optional) Files to return
      * @param  boolean      $names       (Optional) Returns only names on true, else complete info
      * @param  boolean      $noexception (Optional) Allows throwing an exception, otherwise returns an empty array
      * @return array Found files

--- a/library/Zend/Filter/Compress/Rar.php
+++ b/library/Zend/Filter/Compress/Rar.php
@@ -63,7 +63,7 @@ class Zend_Filter_Compress_Rar extends Zend_Filter_Compress_CompressAbstract
     /**
      * Returns the set callback for compression
      *
-     * @return string
+     * @return string|null
      */
     public function getCallback()
     {

--- a/library/Zend/Filter/Compress/Tar.php
+++ b/library/Zend/Filter/Compress/Tar.php
@@ -181,6 +181,7 @@ class Zend_Filter_Compress_Tar extends Zend_Filter_Compress_CompressAbstract
             $content = $file;
         }
 
+        /** @var bool $result Docblock of Archive_Tar::create is incorrect */
         $result  = $archive->create($content);
         if ($result === false) {
             throw new Zend_Filter_Exception('Error creating the Tar archive');

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -278,7 +278,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set flag to disable loading default decorators
      *
      * @param  bool $flag
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setDisableLoadDefaultDecorators($flag)
     {
@@ -299,7 +299,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Load default decorators
      *
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function loadDefaultDecorators()
     {
@@ -338,7 +338,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set object state from options array
      *
      * @param  array $options
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setOptions(array $options)
     {
@@ -379,7 +379,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set object state from Zend_Config object
      *
      * @param  Zend_Config $config
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setConfig(Zend_Config $config)
     {
@@ -393,7 +393,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set translator object for localization
      *
      * @param  Zend_Translate|null|Zend_Translate_Adapter $translator
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setTranslator($translator = null)
     {
@@ -440,7 +440,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Indicate whether or not translation should be disabled
      *
      * @param  bool $flag
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setDisableTranslator($flag)
     {
@@ -480,7 +480,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set element name
      *
      * @param  string $name
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setName($name)
     {
@@ -558,7 +558,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set element value
      *
      * @param  mixed $value
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setValue($value)
     {
@@ -612,7 +612,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set element label
      *
      * @param  string $label
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setLabel($label)
     {
@@ -639,7 +639,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set element order
      *
      * @param  int $order
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setOrder($order)
     {
@@ -661,7 +661,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set required flag
      *
      * @param  bool $flag Default value is true
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setRequired($flag = true)
     {
@@ -683,7 +683,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set flag indicating whether a NotEmpty validator should be inserted when element is required
      *
      * @param  bool $flag
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setAutoInsertNotEmptyValidator($flag)
     {
@@ -705,7 +705,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set element description
      *
      * @param  string $description
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setDescription($description)
     {
@@ -730,7 +730,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * element will validate with empty values.
      *
      * @param  bool $flag
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setAllowEmpty($flag)
     {
@@ -752,7 +752,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set ignore flag (used when retrieving values at form level)
      *
      * @param  bool $flag
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setIgnore($flag)
     {
@@ -774,7 +774,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set flag indicating if element represents an array
      *
      * @param  bool $flag
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setIsArray($flag)
     {
@@ -796,7 +796,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set array to which element belongs
      *
      * @param  string $array
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setBelongsTo($array)
     {
@@ -837,7 +837,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      *
      * @param  string $name
      * @param  mixed $value
-     * @return Zend_Form_Element
+     * @return $this
      * @throws Zend_Form_Exception for invalid $name values
      */
     public function setAttrib($name, $value)
@@ -860,7 +860,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set multiple attributes at once
      *
      * @param  array $attribs
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setAttribs(array $attribs)
     {
@@ -909,7 +909,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Use one error message for array elements with concatenated values
      *
      * @param boolean $concatJustValuesInErrorMessage
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setConcatJustValuesInErrorMessage($concatJustValuesInErrorMessage)
     {
@@ -1096,7 +1096,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add many prefix paths at once
      *
      * @param  array $spec
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addPrefixPaths(array $spec)
     {
@@ -1144,7 +1144,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * @param  string|Zend_Validate_Interface $validator
      * @param  bool $breakChainOnFailure
      * @param  array $options
-     * @return Zend_Form_Element
+     * @return $this
      * @throws Zend_Form_Exception if invalid validator type
      */
     public function addValidator($validator, $breakChainOnFailure = false, $options = array())
@@ -1176,7 +1176,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add multiple validators
      *
      * @param  array $validators
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addValidators(array $validators)
     {
@@ -1225,7 +1225,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set multiple validators, overwriting previous validators
      *
      * @param  array $validators
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setValidators(array $validators)
     {
@@ -1312,7 +1312,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Clear all validators
      *
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function clearValidators()
     {
@@ -1449,7 +1449,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add a custom error message to return in the event of failed validation
      *
      * @param  string $message
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addErrorMessage($message)
     {
@@ -1461,7 +1461,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add multiple custom error messages to return in the event of failed validation
      *
      * @param  array $messages
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addErrorMessages(array $messages)
     {
@@ -1475,7 +1475,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Same as addErrorMessages(), but clears custom error message stack first
      *
      * @param  array $messages
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setErrorMessages(array $messages)
     {
@@ -1496,7 +1496,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Clear custom error messages stack
      *
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function clearErrorMessages()
     {
@@ -1518,7 +1518,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Set errorMessageSeparator
      *
      * @param  string $separator
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setErrorMessageSeparator($separator)
     {
@@ -1529,7 +1529,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Mark the element as being in a failed validation state
      *
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function markAsError()
     {
@@ -1549,7 +1549,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add an error message and mark element as failed validation
      *
      * @param  string $message
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addError($message)
     {
@@ -1562,7 +1562,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add multiple error messages and flag element as failed validation
      *
      * @param  array $messages
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addErrors(array $messages)
     {
@@ -1576,7 +1576,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Overwrite any previously set error messages and flag as failed validation
      *
      * @param  array $messages
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setErrors(array $messages)
     {
@@ -1621,7 +1621,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add a filter to the element
      *
      * @param  string|Zend_Filter_Interface $filter
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addFilter($filter, $options = array())
     {
@@ -1647,7 +1647,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add filters to element
      *
      * @param  array $filters
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addFilters(array $filters)
     {
@@ -1690,7 +1690,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add filters to element, overwriting any already existing
      *
      * @param  array $filters
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setFilters(array $filters)
     {
@@ -1753,7 +1753,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Remove a filter by name
      *
      * @param  string $name
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function removeFilter($name)
     {
@@ -1778,7 +1778,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Clear all filters
      *
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function clearFilters()
     {
@@ -1840,7 +1840,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      *
      * @param  string|Zend_Form_Decorator_Interface $decorator
      * @param  array|Zend_Config $options Options with which to initialize decorator
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addDecorator($decorator, $options = null)
     {
@@ -1880,7 +1880,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Add many decorators at once
      *
      * @param  array $decorators
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function addDecorators(array $decorators)
     {
@@ -1926,7 +1926,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Overwrite all decorators
      *
      * @param  array $decorators
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function setDecorators(array $decorators)
     {
@@ -1985,7 +1985,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Remove a single decorator
      *
      * @param  string $name
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function removeDecorator($name)
     {
@@ -2010,7 +2010,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Clear all decorators
      *
-     * @return Zend_Form_Element
+     * @return $this
      */
     public function clearDecorators()
     {

--- a/library/Zend/Gdata.php
+++ b/library/Zend/Gdata.php
@@ -134,7 +134,7 @@ class Zend_Gdata extends Zend_Gdata_App
     /**
      * Retrieve feed as string or object
      *
-     * @param mixed $location The location as string or Zend_Gdata_Query
+     * @param string|Zend_Gdata_Query $location The location as string or Zend_Gdata_Query
      * @param string $className The class type to use for returning the feed
      * @throws Zend_Gdata_App_InvalidArgumentException
      * @return string|Zend_Gdata_App_Feed Returns string only if the object

--- a/library/Zend/Gdata/Analytics.php
+++ b/library/Zend/Gdata/Analytics.php
@@ -55,12 +55,12 @@ class Zend_Gdata_Analytics extends Zend_Gdata
     /**
      * Retrieve account feed object
      *
-     * @param string|Zend_Uri $uri
+     * @param string|Zend_Gdata_Analytics_AccountQuery $uri
      * @return Zend_Gdata_Analytics_AccountFeed|string
      */
     public function getAccountFeed($uri = self::ANALYTICS_ACCOUNT_FEED_URI)
     {
-        if ($uri instanceof Query) {
+        if ($uri instanceof Zend_Gdata_Analytics_AccountQuery) {
             $uri = $uri->getQueryUrl();
         }
         return parent::getFeed($uri, 'Zend_Gdata_Analytics_AccountFeed');
@@ -69,12 +69,12 @@ class Zend_Gdata_Analytics extends Zend_Gdata
     /**
      * Retrieve data feed object
      *
-     * @param string|Zend_Uri $uri
+     * @param string|Zend_Gdata_Analytics_DataQuery $uri
      * @return Zend_Gdata_Analytics_DataFeed|string
      */
     public function getDataFeed($uri = self::ANALYTICS_FEED_URI)
     {
-        if ($uri instanceof Query) {
+        if ($uri instanceof Zend_Gdata_Analytics_DataQuery) {
             $uri = $uri->getQueryUrl();
         }
         return parent::getFeed($uri, 'Zend_Gdata_Analytics_DataFeed');

--- a/library/Zend/Gdata/App/MediaEntry.php
+++ b/library/Zend/Gdata/App/MediaEntry.php
@@ -35,7 +35,7 @@ class Zend_Gdata_App_MediaEntry extends Zend_Gdata_App_Entry
     /**
      * The attached MediaSource/file
      *
-     * @var Zend_Gdata_App_MediaSource
+     * @var Zend_Gdata_App_MediaSource|null
      */
     protected $_mediaSource = null;
 
@@ -76,7 +76,7 @@ class Zend_Gdata_App_MediaEntry extends Zend_Gdata_App_Entry
      * Return the MediaSource object representing the file attached to this
      * MediaEntry.
      *
-     * @return Zend_Gdata_App_MediaSource The attached MediaSource/file
+     * @return Zend_Gdata_App_MediaSource|null The attached MediaSource/file
      */
     public function getMediaSource()
     {
@@ -87,7 +87,7 @@ class Zend_Gdata_App_MediaEntry extends Zend_Gdata_App_Entry
      * Set the MediaSource object (file) for this MediaEntry
      *
      * @param Zend_Gdata_App_MediaSource $value The attached MediaSource/file
-     * @return Zend_Gdata_App_MediaEntry Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setMediaSource($value)
     {

--- a/library/Zend/Gdata/Gapps/Extension/Login.php
+++ b/library/Zend/Gdata/Gapps/Extension/Login.php
@@ -51,7 +51,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * The password for the user. May be in cleartext or as an SHA-1
      * digest, depending on the value of _hashFunctionName.
      *
-     * @var string
+     * @var string|null
      */
     protected $_password = null;
 
@@ -257,7 +257,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * to form this user's email address.
      *
      * @param string $value The desired value for this attribute.
-     * @return Zend_Gdata_Gapps_Extension_Login Provides a fluent interface.
+     * @return $this Provides a fluent interface.
      */
     public function setUsername($value)
     {
@@ -269,7 +269,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * Get the value for this element's password attribute.
      *
      * @see setPassword
-     * @return string The requested attribute.
+     * @return string|null The requested attribute.
      */
     public function getPassword()
     {
@@ -283,7 +283,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * this must be indicated by calling setHashFunctionName().
      *
      * @param string $value The desired value for this attribute.
-     * @return Zend_Gdata_Gapps_Extension_Login Provides a fluent interface.
+     * @return $this Provides a fluent interface.
      */
     public function setPassword($value)
     {
@@ -310,7 +310,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * function is 'SHA-1'.
      *
      * @param string $value The desired value for this attribute.
-     * @return Zend_Gdata_Gapps_Extension_Login Provides a fluent interface.
+     * @return $this Provides a fluent interface.
      */
     public function setHashFunctionName($value)
     {
@@ -338,7 +338,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * whether this user is an administrator for this domain.
      *
      * @param boolean $value The desired value for this attribute.
-     * @return Zend_Gdata_Gapps_Extension_Login Provides a fluent interface.
+     * @return $this Provides a fluent interface.
      * @throws Zend_Gdata_App_InvalidArgumentException
      */
     public function setAdmin($value)
@@ -370,7 +370,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * indicates whether this user has agreed to the terms of service.
      *
      * @param boolean $value The desired value for this attribute.
-     * @return Zend_Gdata_Gapps_Extension_Login Provides a fluent interface.
+     * @return $this Provides a fluent interface.
      * @throws Zend_Gdata_App_InvalidArgumentException
      */
     public function setAgreedToTerms($value)
@@ -402,7 +402,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * user will not be able to login to this domain until unsuspended.
      *
      * @param boolean $value The desired value for this attribute.
-     * @return Zend_Gdata_Gapps_Extension_Login Provides a fluent interface.
+     * @return $this Provides a fluent interface.
      * @throws Zend_Gdata_App_InvalidArgumentException
      */
     public function setSuspended($value)
@@ -435,7 +435,7 @@ class Zend_Gdata_Gapps_Extension_Login extends Zend_Gdata_Extension
      * time they login.
      *
      * @param boolean $value The desired value for this attribute.
-     * @return Zend_Gdata_Gapps_Extension_Login Provides a fluent interface.
+     * @return $this Provides a fluent interface.
      * @throws Zend_Gdata_App_InvalidArgumentException
      */
     public function setChangePasswordAtNextLogin($value)

--- a/library/Zend/Gdata/Photos/AlbumQuery.php
+++ b/library/Zend/Gdata/Photos/AlbumQuery.php
@@ -76,7 +76,7 @@ class Zend_Gdata_Photos_AlbumQuery extends Zend_Gdata_Photos_UserQuery
      * Get the album name which is to be returned.
      *
      * @see setAlbumName
-     * @return string The name of the album to retrieve.
+     * @return string|null The name of the album to retrieve.
      */
     public function getAlbumName()
     {

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -497,7 +497,7 @@ class Zend_Http_Client
      *
      * @param string $type GET or POST
      * @param string $name
-     * @param string $value
+     * @param string|null $value
      * @return void
      */
     protected function _setParameter($type, $name, $value)
@@ -553,7 +553,7 @@ class Zend_Http_Client
      * </code>
      *
      * @see http://www.faqs.org/rfcs/rfc2617.html
-     * @param string|false $user User name or false disable authentication
+     * @param string|false|null $user User name or false disable authentication
      * @param string $password Password
      * @param string $type Authentication type
      * @return Zend_Http_Client

--- a/library/Zend/Json/Server.php
+++ b/library/Zend/Json/Server.php
@@ -79,7 +79,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
      *
      * @param  string|array $function Valid PHP callback
      * @param  string $namespace  Ignored
-     * @return Zend_Json_Server
+     * @return $this
      */
     public function addFunction($function, $namespace = '')
     {
@@ -129,7 +129,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
      * @param  string $class
      * @param  string $namespace Ignored
      * @param  mixed $argv Ignored
-     * @return Zend_Json_Server
+     * @return $this
      */
     public function setClass($class, $namespace = '', $argv = null)
     {
@@ -218,7 +218,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
      * Set request object
      *
      * @param  Zend_Json_Server_Request $request
-     * @return Zend_Json_Server
+     * @return $this
      */
     public function setRequest(Zend_Json_Server_Request $request)
     {
@@ -243,7 +243,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
      * Set response object
      *
      * @param  Zend_Json_Server_Response $response
-     * @return Zend_Json_Server
+     * @return $this
      */
     public function setResponse(Zend_Json_Server_Response $response)
     {
@@ -268,7 +268,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
      * Set flag indicating whether or not to auto-emit response
      *
      * @param  bool $flag
-     * @return Zend_Json_Server
+     * @return $this
      */
     public function setAutoEmitResponse($flag)
     {

--- a/library/Zend/Loader/Autoloader/Resource.php
+++ b/library/Zend/Loader/Autoloader/Resource.php
@@ -198,7 +198,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
      * Set class state from options
      *
      * @param  array $options
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function setOptions(array $options)
     {
@@ -222,7 +222,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
      * Set namespace that this autoloader handles
      *
      * @param  string $namespace
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function setNamespace($namespace)
     {
@@ -244,7 +244,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
      * Set base path for this set of resources
      *
      * @param  string $path
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function setBasePath($path)
     {
@@ -268,7 +268,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
      * @param  string $type identifier for the resource type being loaded
      * @param  string $path path relative to resource base path containing the resource types
      * @param  null|string $namespace sub-component namespace to append to base namespace that qualifies this resource type
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function addResourceType($type, $path, $namespace = null)
     {
@@ -317,7 +317,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
      * </code>
      *
      * @param  array $types
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function addResourceTypes(array $types)
     {
@@ -343,7 +343,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
      *
      * @see    Zend_Loader_Autoloader_Resource::addResourceTypes()
      * @param  array $types
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function setResourceTypes(array $types)
     {
@@ -376,7 +376,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
      * Remove the requested resource type
      *
      * @param  string $type
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function removeResourceType($type)
     {
@@ -391,7 +391,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
     /**
      * Clear all resource types
      *
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function clearResourceTypes()
     {
@@ -404,7 +404,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
      * Set default resource type to use when calling load()
      *
      * @param  string $type
-     * @return Zend_Loader_Autoloader_Resource
+     * @return $this
      */
     public function setDefaultResourceType($type)
     {

--- a/library/Zend/Mail.php
+++ b/library/Zend/Mail.php
@@ -212,7 +212,7 @@ class Zend_Mail extends Zend_Mime_Message
      * Should only be used for manually setting multipart content types.
      *
      * @param  string $type Content type
-     * @return Zend_Mail Implements fluent interface
+     * @return $this Implements fluent interface
      * @throws Zend_Mail_Exception for types not supported by Zend_Mime
      */
     public function setType($type)
@@ -246,7 +246,7 @@ class Zend_Mail extends Zend_Mime_Message
      * If not set, Zend_Mime will generate one.
      *
      * @param  string    $boundary
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function setMimeBoundary($boundary)
     {
@@ -293,7 +293,7 @@ class Zend_Mail extends Zend_Mime_Message
      *
      * @deprecated Use {@link setHeaderEncoding()} instead.
      * @param  string $encoding
-     * @return Zend_Mail
+     * @return $this
      */
     public function setEncodingOfHeaders($encoding)
     {
@@ -305,7 +305,7 @@ class Zend_Mail extends Zend_Mime_Message
      *
      * @param  string $encoding Zend_Mime::ENCODING_QUOTEDPRINTABLE or
      *                          Zend_Mime::ENCODING_BASE64
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      * @throws Zend_Mail_Exception
      */
     public function setHeaderEncoding($encoding)
@@ -328,7 +328,7 @@ class Zend_Mail extends Zend_Mime_Message
      * @param  string $txt
      * @param  string $charset
      * @param  string $encoding
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
     */
     public function setBodyText($txt, $charset = null, $encoding = Zend_Mime::ENCODING_QUOTEDPRINTABLE)
     {
@@ -370,7 +370,7 @@ class Zend_Mail extends Zend_Mime_Message
      * @param  string    $html
      * @param  string    $charset
      * @param  string    $encoding
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function setBodyHtml($html, $charset = null, $encoding = Zend_Mime::ENCODING_QUOTEDPRINTABLE)
     {
@@ -409,7 +409,7 @@ class Zend_Mail extends Zend_Mime_Message
      * Adds an existing attachment to the mail message
      *
      * @param  Zend_Mime_Part $attachment
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function addAttachment(Zend_Mime_Part $attachment)
     {
@@ -540,7 +540,7 @@ class Zend_Mail extends Zend_Mime_Message
      *
      * @param  string|array $email
      * @param  string $name
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function addTo($email, $name='')
     {
@@ -562,7 +562,7 @@ class Zend_Mail extends Zend_Mime_Message
      *
      * @param  string|array    $email
      * @param  string    $name
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function addCc($email, $name='')
     {
@@ -581,7 +581,7 @@ class Zend_Mail extends Zend_Mime_Message
      * Adds Bcc recipient, $email can be an array, or a single string address
      *
      * @param  string|array    $email
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function addBcc($email)
     {
@@ -610,7 +610,7 @@ class Zend_Mail extends Zend_Mime_Message
      * Clear header from the message
      *
      * @param string $headerName
-     * @return Zend_Mail Provides fluent inter
+     * @return $this Provides fluent inter
      */
     public function clearHeader($headerName)
     {
@@ -623,7 +623,7 @@ class Zend_Mail extends Zend_Mime_Message
     /**
      * Clears list of recipient email addresses
      *
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function clearRecipients()
     {
@@ -642,7 +642,7 @@ class Zend_Mail extends Zend_Mime_Message
      *
      * @param  string    $email
      * @param  string    $name
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      * @throws Zend_Mail_Exception if called subsequent times
      */
     public function setFrom($email, $name = null)
@@ -664,7 +664,7 @@ class Zend_Mail extends Zend_Mime_Message
      *
      * @param string $email
      * @param string $name
-     * @return Zend_Mail
+     * @return $this
      * @throws Zend_Mail_Exception if called more than one time
      */
     public function setReplyTo($email, $name = null)
@@ -704,7 +704,7 @@ class Zend_Mail extends Zend_Mime_Message
     /**
      * Clears the sender from the mail
      *
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function clearFrom()
     {
@@ -717,7 +717,7 @@ class Zend_Mail extends Zend_Mime_Message
      /**
       * Clears the current Reply-To address from the message
       *
-      * @return Zend_Mail Provides fluent interface
+      * @return $this Provides fluent interface
       */
     public function clearReplyTo()
     {
@@ -762,7 +762,7 @@ class Zend_Mail extends Zend_Mime_Message
     /**
      * Sets From-name and -email based on the defaults
      *
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      * @throws Zend_Mail_Exception
      */
     public function setFromToDefaultFrom() {
@@ -812,7 +812,7 @@ class Zend_Mail extends Zend_Mime_Message
     /**
      * Sets ReplyTo-name and -email based on the defaults
      *
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      * @throws Zend_Mail_Exception
      */
     public function setReplyToFromDefault() {
@@ -831,7 +831,7 @@ class Zend_Mail extends Zend_Mime_Message
      * Sets the Return-Path header of the message
      *
      * @param  string    $email
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      * @throws Zend_Mail_Exception if set multiple times
      */
     public function setReturnPath($email)
@@ -865,7 +865,7 @@ class Zend_Mail extends Zend_Mime_Message
     /**
      * Clears the current Return-Path address from the message
      *
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function clearReturnPath()
     {
@@ -921,7 +921,7 @@ class Zend_Mail extends Zend_Mime_Message
      * Sets Date-header
      *
      * @param  int|string|Zend_Date $date
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      * @throws Zend_Mail_Exception if called subsequent times or wrong date
      *                             format.
      */
@@ -966,7 +966,7 @@ class Zend_Mail extends Zend_Mime_Message
     /**
      * Clears the formatted date from the message
      *
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function clearDate()
     {
@@ -979,12 +979,12 @@ class Zend_Mail extends Zend_Mime_Message
     /**
      * Sets the Message-ID of the message
      *
-     * @param   boolean|string  $id
+     * @param   boolean|string|null  $id
      * true  :Auto
      * false :No set
      * null  :No set
      * string:Sets given string (Angle brackets is not necessary)
-     * @return  Zend_Mail Provides fluent interface
+     * @return  $this Provides fluent interface
      * @throws  Zend_Mail_Exception
      */
     public function setMessageId($id = true)
@@ -1020,7 +1020,7 @@ class Zend_Mail extends Zend_Mime_Message
     /**
      * Clears the Message-ID from the message
      *
-     * @return Zend_Mail Provides fluent interface
+     * @return $this Provides fluent interface
      */
     public function clearMessageId()
     {
@@ -1070,7 +1070,7 @@ class Zend_Mail extends Zend_Mime_Message
      * @param  string              $name
      * @param  string              $value
      * @param  boolean             $append
-     * @return Zend_Mail           Provides fluent interface
+     * @return $this           Provides fluent interface
      * @throws Zend_Mail_Exception on attempts to create standard headers
      */
     public function addHeader($name, $value, $append = false)
@@ -1106,7 +1106,7 @@ class Zend_Mail extends Zend_Mime_Message
      * default transport had been set.
      *
      * @param  Zend_Mail_Transport_Abstract $transport
-     * @return Zend_Mail                    Provides fluent interface
+     * @return $this                    Provides fluent interface
      */
     public function send($transport = null)
     {

--- a/library/Zend/Mail/Transport/Abstract.php
+++ b/library/Zend/Mail/Transport/Abstract.php
@@ -115,7 +115,7 @@ abstract class Zend_Mail_Transport_Abstract
      * Content-Type of either multipart/alternative or multipart/mixed depending
      * on the mail parts present in the {@link $_mail Zend_Mail object} present.
      *
-     * @param string $boundary
+     * @param string|null $boundary
      * @return array
      */
     protected function _getHeaders($boundary)

--- a/library/Zend/Navigation/Page.php
+++ b/library/Zend/Navigation/Page.php
@@ -331,7 +331,7 @@ abstract class Zend_Navigation_Page extends Zend_Navigation_Container
     /**
      * Sets page label
      *
-     * @param  string $label              new page label
+     * @param  string|null $label              new page label
      * @return Zend_Navigation_Page       fluent interface, returns self
      * @throws Zend_Navigation_Exception  if empty/no string is given
      */
@@ -359,7 +359,7 @@ abstract class Zend_Navigation_Page extends Zend_Navigation_Container
     /**
      * Sets a fragment identifier
      *
-     * @param  string $fragment   new fragment identifier
+     * @param  string|null $fragment   new fragment identifier
      * @return Zend_Navigation_Page         fluent interface, returns self
      * @throws Zend_Navigation_Exception    if empty/no string is given
      */

--- a/library/Zend/Navigation/Page/Mvc.php
+++ b/library/Zend/Navigation/Page/Mvc.php
@@ -267,7 +267,7 @@ class Zend_Navigation_Page_Mvc extends Zend_Navigation_Page
      *
      * @see getHref()
      *
-     * @param  string $action             action name
+     * @param  string|null $action             action name
      * @return Zend_Navigation_Page_Mvc   fluent interface, returns self
      * @throws Zend_Navigation_Exception  if invalid $action is given
      */
@@ -502,7 +502,7 @@ class Zend_Navigation_Page_Mvc extends Zend_Navigation_Page
      *
      * @see getHref()
      *
-     * @param  string $route              route name to use when assembling URL
+     * @param  string|null $route              route name to use when assembling URL
      * @return Zend_Navigation_Page_Mvc   fluent interface, returns self
      * @throws Zend_Navigation_Exception  if invalid $route is given
      */

--- a/library/Zend/Navigation/Page/Uri.php
+++ b/library/Zend/Navigation/Page/Uri.php
@@ -41,7 +41,7 @@ class Zend_Navigation_Page_Uri extends Zend_Navigation_Page
     /**
      * Sets page URI
      *
-     * @param  string $uri                page URI, must a string or null
+     * @param  string|null $uri                page URI, must a string or null
      * @return Zend_Navigation_Page_Uri   fluent interface, returns self
      * @throws Zend_Navigation_Exception  if $uri is invalid
      */
@@ -74,16 +74,16 @@ class Zend_Navigation_Page_Uri extends Zend_Navigation_Page
     public function getHref()
     {
         $uri = $this->getUri();
-        
-        $fragment = $this->getFragment();       
+
+        $fragment = $this->getFragment();
         if (null !== $fragment) {
             if ('#' == substr($uri, -1)) {
                 return $uri . $fragment;
-            } else {                
+            } else {
                 return $uri . '#' . $fragment;
             }
         }
-        
+
         return $uri;
     }
 

--- a/library/Zend/OpenId/Consumer.php
+++ b/library/Zend/OpenId/Consumer.php
@@ -63,7 +63,7 @@ class Zend_OpenId_Consumer
     /**
      * HTTP client to make HTTP requests
      *
-     * @var Zend_Http_Client $_httpClient
+     * @var Zend_Http_Client|null $_httpClient
      */
     private $_httpClient = null;
 
@@ -929,7 +929,7 @@ class Zend_OpenId_Consumer
     /**
      * Returns HTTP client object that will be used to make HTTP requests
      *
-     * @return Zend_Http_Client
+     * @return Zend_Http_Client|null
      */
     public function getHttpClient() {
         return $this->_httpClient;

--- a/library/Zend/Pdf/Outline/Loaded.php
+++ b/library/Zend/Pdf/Outline/Loaded.php
@@ -68,7 +68,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
      * Set outline title
      *
      * @param string $title
-     * @return Zend_Pdf_Outline
+     * @return $this
      */
     public function setTitle($title)
     {
@@ -81,7 +81,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
      * Sets 'isOpen' outline flag
      *
      * @param boolean $isOpen
-     * @return Zend_Pdf_Outline
+     * @return $this
      */
     public function setIsOpen($isOpen)
     {
@@ -89,7 +89,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
 
         if ($this->_outlineDictionary->Count === null) {
             // Do Nothing.
-            return this;
+            return $this;
         }
 
         $childrenCount = $this->_outlineDictionary->Count->value;

--- a/library/Zend/Queue/Adapter/PlatformJobQueue.php
+++ b/library/Zend/Queue/Adapter/PlatformJobQueue.php
@@ -32,7 +32,7 @@
 class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbstract
 {
     /**
-     * @var ZendApi_Queue
+     * @var ZendAPI_Queue
      */
     protected $_zendQueue;
 
@@ -64,7 +64,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
             throw new Zend_Queue_Exception('Platform Job Queue password should be provided');
         }
 
-        $this->_zendQueue = new ZendApi_Queue($options['host']);
+        $this->_zendQueue = new ZendAPI_Queue($options['host']);
 
         if (!$this->_zendQueue) {
             throw new Zend_Queue_Exception('Platform Job Queue connection failed');
@@ -152,7 +152,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
     /**
      * Send a message to the queue
      *
-     * @param  array | ZendApi_Job $message Message to send to the active queue
+     * @param  array | ZendAPI_Job $message Message to send to the active queue
      * @param  Zend_Queue $queue     Not supported
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception
@@ -169,7 +169,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
             Zend_Loader::loadClass($classname);
         }
 
-        if ($message instanceof ZendApi_Job) {
+        if ($message instanceof ZendAPI_Job) {
             $message = array('data' => $message);
         }
 
@@ -305,7 +305,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
     {
         $options = $this->_options['daemonOptions'];
 
-        $this->_zendQueue = new ZendApi_Queue($options['host']);
+        $this->_zendQueue = new ZendAPI_Queue($options['host']);
 
         if (!$this->_zendQueue) {
             throw new Zend_Queue_Exception('Platform Job Queue connection failed');

--- a/library/Zend/Queue/Message/PlatformJob.php
+++ b/library/Zend/Queue/Message/PlatformJob.php
@@ -32,7 +32,7 @@
 class Zend_Queue_Message_PlatformJob extends Zend_Queue_Message
 {
     /**
-     * @var ZendApi_Job
+     * @var ZendAPI_Job
      */
     protected $_job;
 
@@ -62,7 +62,7 @@ class Zend_Queue_Message_PlatformJob extends Zend_Queue_Message
     public function __construct(array $options = array())
     {
         if (isset($options['data'])) {
-            if (!($options['data'] instanceof ZendApi_Job)) {
+            if (!($options['data'] instanceof ZendAPI_Job)) {
                 throw new Zend_Queue_Exception('Data must be an instance of ZendApi_Job');
             }
             $this->_job = $options['data'];
@@ -74,7 +74,7 @@ class Zend_Queue_Message_PlatformJob extends Zend_Queue_Message
                 throw new Zend_Queue_Exception('The script is mandatory data');
             }
 
-            $this->_job = new ZendApi_Job($options['script']);
+            $this->_job = new ZendAPI_Job($options['script']);
             $this->_setJobProperties();
         }
     }
@@ -106,7 +106,7 @@ class Zend_Queue_Message_PlatformJob extends Zend_Queue_Message
     /**
      * Retrieve the internal ZendApi_Job instance
      *
-     * @return ZendApi_Job
+     * @return ZendAPI_Job
      */
     public function getJob()
     {

--- a/library/Zend/Service/Amazon/Ec2/Instance/Windows.php
+++ b/library/Zend/Service/Amazon/Ec2/Instance/Windows.php
@@ -170,7 +170,7 @@ class Zend_Service_Amazon_Ec2_Instance_Windows extends Zend_Service_Amazon_Ec2_A
      * Signed S3 Upload Policy
      *
      * @param string $policy            Base64 Encoded string that is the upload policy
-     * @return string                   SHA1 encoded S3 Upload Policy
+     * @return string|false             SHA1 encoded S3 Upload Policy
      */
     protected function _signS3UploadPolicy($policy)
     {

--- a/library/Zend/Service/Amazon/Query.php
+++ b/library/Zend/Service/Amazon/Query.php
@@ -51,7 +51,7 @@ class Zend_Service_Amazon_Query extends Zend_Service_Amazon
      * @param  string $method
      * @param  array  $args
      * @throws Zend_Service_Exception
-     * @return Zend_Service_Amazon_Query Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function __call($method, $args)
     {

--- a/library/Zend/Service/ReCaptcha/MailHide.php
+++ b/library/Zend/Service/ReCaptcha/MailHide.php
@@ -50,7 +50,7 @@ class Zend_Service_ReCaptcha_MailHide extends Zend_Service_ReCaptcha
     /**
      * The email address to protect
      *
-     * @var string
+     * @var string|null
      */
     protected $_email = null;
 
@@ -243,7 +243,7 @@ class Zend_Service_ReCaptcha_MailHide extends Zend_Service_ReCaptcha
     /**
      * Get the email property
      *
-     * @return string
+     * @return string|null
      */
     public function getEmail()
     {

--- a/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
+++ b/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
@@ -35,7 +35,7 @@ class Zend_Tag_Cloud_Decorator_HtmlTag extends Zend_Tag_Cloud_Decorator_Tag
      * List of tags which get assigned to the inner element instead of
      * font-sizes.
      *
-     * @var array
+     * @var array|null
      */
     protected $_classList = null;
 
@@ -110,7 +110,7 @@ class Zend_Tag_Cloud_Decorator_HtmlTag extends Zend_Tag_Cloud_Decorator_Tag
     /**
      * Get class list
      *
-     * @return array
+     * @return array|null
      */
     public function getClassList()
     {

--- a/library/Zend/Test/PHPUnit/Db/Operation/Truncate.php
+++ b/library/Zend/Test/PHPUnit/Db/Operation/Truncate.php
@@ -75,7 +75,7 @@ class Zend_Test_PHPUnit_Db_Operation_Truncate implements PHPUnit\DbUnit\Operatio
             } else {
                 $db->query('IMPORT FROM /dev/null OF DEL REPLACE INTO '.$tableName);
             }*/
-            throw Zend_Exception("IBM Db2 TRUNCATE not supported.");
+            throw new Zend_Exception("IBM Db2 TRUNCATE not supported.");
         } else if($this->_isMssqlOrOracle($db)) {
             $db->query('TRUNCATE TABLE '.$tableName);
         } else if($db instanceof Zend_Db_Adapter_Pdo_Pgsql) {

--- a/library/Zend/Tool/Project/Context/Zf/ApplicationConfigFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ApplicationConfigFile.php
@@ -106,7 +106,7 @@ class Zend_Tool_Project_Context_Zf_ApplicationConfigFile extends Zend_Tool_Proje
      * @param string $key
      * @param string $value
      * @param string $section
-     * @param bool   $quoteValue
+     * @param bool|null   $quoteValue
      * @return Zend_Tool_Project_Context_Zf_ApplicationConfigFile
      */
     public function addStringItem($key, $value, $section = 'production', $quoteValue = true)

--- a/library/Zend/Translate/Adapter.php
+++ b/library/Zend/Translate/Adapter.php
@@ -402,7 +402,7 @@ abstract class Zend_Translate_Adapter {
     /**
      * Sets locale
      *
-     * @param  string|Zend_Locale $locale Locale to set
+     * @param  string|Zend_Locale|null $locale Locale to set
      * @throws Zend_Translate_Exception
      * @return Zend_Translate_Adapter Provides fluent interface
      */

--- a/library/Zend/Validate/NotEmpty.php
+++ b/library/Zend/Validate/NotEmpty.php
@@ -146,7 +146,7 @@ class Zend_Validate_NotEmpty extends Zend_Validate_Abstract
      *
      * Returns true if and only if $value is not an empty value.
      *
-     * @param  string|array|int|float|bool|object $value
+     * @param  string|array|int|float|bool|object|null $value
      * @return boolean
      */
     public function isValid($value)

--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -234,7 +234,7 @@ class Zend_View_Helper_Gravatar extends Zend_View_Helper_HtmlElement
     /**
      * Load from an SSL or No-SSL location?
      *
-     * @param bool $flag
+     * @param bool|null $flag
      * @return Zend_View_Helper_Gravatar
      */
     public function setSecure($flag)

--- a/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -66,7 +66,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      *
      * @param  Zend_Navigation_Container $container     [optional] container to
      *                                                  operate on
-     * @return Zend_View_Helper_Navigation_Breadcrumbs  fluent interface,
+     * @return $this                                    fluent interface,
      *                                                  returns self
      */
     public function breadcrumbs(Zend_Navigation_Container $container = null)
@@ -84,7 +84,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      * Sets breadcrumb separator
      *
      * @param  string $separator                        separator string
-     * @return Zend_View_Helper_Navigation_Breadcrumbs  fluent interface,
+     * @return $this                                    fluent interface,
      *                                                  returns self
      */
     public function setSeparator($separator)
@@ -111,7 +111,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      *
      * @param  bool $linkLast                           whether last page should
      *                                                  be hyperlinked
-     * @return Zend_View_Helper_Navigation_Breadcrumbs  fluent interface,
+     * @return $this                                    fluent interface,
      *                                                  returns self
      */
     public function setLinkLast($linkLast)
@@ -133,7 +133,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
     /**
      * Sets which partial view script to use for rendering menu
      *
-     * @param  string|array $partial                    partial view script or
+     * @param  string|array|null $partial               partial view script or
      *                                                  null. If an array is
      *                                                  given, it is expected to
      *                                                  contain two values;
@@ -141,7 +141,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      *                                                  to use, and the module
      *                                                  where the script can be
      *                                                  found.
-     * @return Zend_View_Helper_Navigation_Breadcrumbs  fluent interface,
+     * @return $this                                    fluent interface,
      *                                                  returns self
      */
     public function setPartial($partial)

--- a/library/Zend/XmlRpc/Client.php
+++ b/library/Zend/XmlRpc/Client.php
@@ -43,7 +43,7 @@ class Zend_XmlRpc_Client
      * HTTP Client to use for requests
      * @var Zend_Http_Client
      */
-    protected $_httpClient = null;
+    protected $_httpClient;
 
     /**
      * Introspection object

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -38,6 +38,15 @@ if (!extension_loaded('memcached')) {
     require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/memcached/memcached.php';
 }
 
+if (!extension_loaded('hash')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/hash/hash.php';
+}
+// The hash extension may emulate the mhash extension if PHP is configured with --with-mhash
+// otherwise the mhash* functions/constants won't exist
+if (!function_exists('mhash')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/mhash/mhash.php';
+}
+
 if (!extension_loaded('mysql')) {
     require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/mysql/mysql.php';
 }
@@ -85,6 +94,10 @@ if (!extension_loaded('xcache')) {
 
 if (!extension_loaded('jobqueue_client')) {
     require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/zend/zend.php';
+}
+
+if (!extension_loaded('wddx')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/wddx/wddx.php';
 }
 
 if (!extension_loaded('zendcache')) {

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -4,3 +4,89 @@
 // component when the classes are loaded (bottom of file), which phpstan will trigger when it
 // autoloads the classes.  This prevents it from bootstrapping (which prevents some exceptions being thrown)
 define('MICROSOFT_CONSOLE_COMMAND_HOST', 'nobootstrap');
+
+// Use stubs so we can analyze types from unloaded extensions
+if (!extension_loaded('apc')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/apc/apc.php';
+}
+
+if (!extension_loaded('gmp')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/gmp/gmp.php';
+}
+
+if (!extension_loaded('ibm_db2')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/ibm_db2/ibm_db2.php';
+}
+
+if (!extension_loaded('igbinary')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/igbinary/igbinary.php';
+}
+
+if (!extension_loaded('intl')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/intl/intl.php';
+}
+
+if (!extension_loaded('mcrypt')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/mcrypt/mcrypt.php';
+}
+
+if (!extension_loaded('memcache')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/memcache/memcache.php';
+}
+
+if (!extension_loaded('memcached')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/memcached/memcached.php';
+}
+
+if (!extension_loaded('mysql')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/mysql/mysql.php';
+}
+
+if (!extension_loaded('oci8')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/oci8/oci8.php';
+}
+
+if (!extension_loaded('openssl')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/openssl/openssl.php';
+} else {
+    // Only defined when php/openssl compiled with MD2 support
+    if (!defined('OPENSSL_ALGO_MD2')) {
+        define('OPENSSL_ALGO_MD2', 4);
+    }
+}
+
+if (!extension_loaded('rar')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/rar/rar.php';
+}
+
+if (!extension_loaded('sqlite')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/SQLite/SQLite.php';
+}
+
+if (!extension_loaded('sqlsrv')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/sqlsrv/sqlsrv.php';
+}
+
+if (!extension_loaded('ssh2')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/ssh2/ssh2.php';
+}
+
+if (!extension_loaded('wincache')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/wincache/wincache.php';
+}
+
+if (!extension_loaded('tidy')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/tidy/tidy.php';
+}
+
+if (!extension_loaded('xcache')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/xcache/xcache.php';
+}
+
+if (!extension_loaded('jobqueue_client')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/zend/zend.php';
+}
+
+if (!extension_loaded('zendcache')) {
+    require_once __DIR__ . '/vendor/jetbrains/phpstorm-stubs/ZendCache/ZendCache.php';
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,51 +5,56 @@ parameters:
         - 'library/Zend/Stdlib/SplPriorityQueue.php'
         - 'library/Zend/Tool/Framework/Provider/DocblockManifestable.php'
     ignoreErrors:
+        ######################################################################################
         # Level 0 errors that require code changes (or missing extensions/third party libs)
+        ######################################################################################
         - '#.+::__construct\(\) does not call parent constructor from .+\.#'
         - '#Access to an undefined property .+\.#'
-        - '#Access to constant .+ on an unknown class Memcached\.#'
         - '#Array has [\d]+ duplicate keys with value .+\.#'
         - '#Call to .+ on an unknown class Mobi_Mtld_DA_Api\.#'
         - '#Call to an undefined method .+\.#'
         - '#Call to an undefined static method .+\.#'
+        - '#Class WeakRef not found\.#'
+        - '#Class Zend_Pdf_FileParser_Font_OpenType_Type1 not found\.#'
         - '#Class .+ constructor invoked with [\d]+ parameters?, .+ required\.#'
         - '#Class .+ does not have a constructor and must be instantiated without any parameters\.#'
-        - '#Class .+ not found\.#'
         - '#Constructor of class .+ has an unused parameter .+.#'
         - '#Function .+ invoked with [\d] parameters?, .+ required\.#'
-        - '#Function .+ not found\.#'
-        - '#Instantiated class .+ not found\.#'
+        - '#Function accelerator_license_info not found\.#'
+        - '#Function accelerator_get_configuration not found\.#'
+        - '#Function bitset_empty not found\.#'
+        - '#Function bitset_incl not found\.#'
+        - '#Function bitset_to_array not found\.#'
+        - '#Function bitset_in not found\.#'
+        - '#Function bitset_union not found\.#'
+        - '#Function lzf_compress not found\.#'
+        - '#Function lzf_decompress not found\.#'
+        - '#Instantiated class TeraWurfl not found\.#'
+        - '#Instantiated class WeakRef not found\.#'
+        - '#Instantiated class Zend_Pdf_FileParser_Image_Jpeg not found\.#'
+        - '#Instantiated class Zend_Pdf_FileParser_Image_Tiff not found\.#'
         - '#Method .+ invoked with [\d]+ parameters?, .+ required\.#'
         - '#Parameter .+ has invalid typehint type TeraWurfl\.#'
         - '#Parameter .+ has invalid typehint type Zend_Pdf_Element_LayoutBox\.#'
-        - '#Parameter .+ has invalid typehint type ZendApi_Job\.#'
-        - '#Property .+ has unknown class Memcache as its type\.#'
-        - '#Property .+ has unknown class ZendApi_Job as its type\.#'
-        - '#Property .+ has unknown class ZendApi_Queue as its type\.#'
         - '#Property .+ has unknown class WeakRef as its type\.#'
+        - '#Result of function .+ \(void\) is used\.#'
         - '#Result of method .+ \(void\) is used\.#'
         - '#Result of static method .+ \(void\) is used\.#'
-        - '#Return typehint of method .+ has invalid type ZendApi_Job\.#'
         - '#Static method .+ invoked with [\d]+ parameters?, .+ required\.#'
         - '#Undefined variable: .+#'
         - '#Using \$this in static method .+\.#'
+        ########################################################
         # Level 1 errors that require code changes
+        ########################################################
         - '#Variable \$.+ might not be defined\.#'
         - '#Variable \$.+ in isset\(\) always exists and is not nullable\.#'
         - '#Variable \$.+ in isset\(\) is never defined\.#'
-        - '#Constant [A-Z0-9_]+ not found\.#'
-        - '#Constant this not found\.#'
+        #####################################################################################
         # Level 2 errors that require code changes (or missing extensions/third party libs)
+        #####################################################################################
         - '#Access to property .+ on an unknown class TeraWurfl\.#'
-        - '#Call to method .+ on an unknown class Archive_Tar\.#'
-        - '#Call to method .+ on an unknown class Memcache\.#'
-        - '#Call to method .+ on an unknown class Memcached\.#'
         - '#Call to method .+ on an unknown class TeraWurfl\.#'
         - '#Call to method .+ on an unknown class WeakRef\.#'
-        - '#Call to method .+ on an unknown class ZendApi_Job\.#'
-        - '#Call to method .+ on an unknown class ZendApi_Queue\.#'
-        - '#Call to method getQueryUrl\(\) on an unknown class Query\.#'
         - '#Cannot access property \$commands on array\.#'
         - '#Cannot access property \$description on array\.#'
         - '#Cannot access property \$footers on array\.#'
@@ -65,8 +70,9 @@ parameters:
         - '#PHPDoc tag @param references unknown parameter \$content#'
         - '#PHPDoc tag @param references unknown parameter \$locale#'
         - '#PHPDoc tag @param references unknown parameter \$script#'
+        ##########################################################################
         # Level 3 errors that require code changes or are false positives
-        - '#Argument of an invalid type APCIterator supplied for foreach, only iterables are supported\.#'
+        ##########################################################################
         - '#Argument of an invalid type object supplied for foreach, only iterables are supported\.#'
         - '#Cannot call method normalize\(\) on null\.#'
         - '#Cannot call method sumOfSquaredWeights\(\) on null\.#'
@@ -76,6 +82,12 @@ parameters:
         - '#Method Zend_Amf_Adobe_Introspector::_phpTypeToAS\(\) should return string but returns false\|string\.#'
         - '#Method Zend_Amf_Parse_Amf0_Deserializer::readXmlString\(\) should return false\|SimpleXMLElement but returns DOMDocument\|false\|SimpleXMLElement\.#'
         - '#Method Zend_Amf_Parse_Amf3_Deserializer::readXmlString\(\) should return false\|SimpleXMLElement but returns DOMDocument\|false\|SimpleXMLElement\.#'
+        # apc stub has this defined as array|bool, which could be correct (manual doesn't show it), except in this case it's returning bool since $id is a string
+        - '#Method Zend_Cache_Backend_Apc::remove\(\) should return bool but returns array<string>\|bool\.#'
+        # sqlite_open does return false|resource, but there's a check above this for !is_resource that will throw an exception, however, the exception
+        # is thrown via a call to Zend_Cache::throwException, so phpstan is unaware of the break in flow
+        - '#Method Zend_Cache_Backend_Sqlite::_getConnection\(\) should return resource but returns false\|resource\.#'
+        - '#Property Zend_Cache_Backend_Sqlite::\$_db \(resource\) does not accept false\|resource\.#'
         - '#Method Zend_Cloud_DocumentService_Adapter_SimpleDb::select\(\) should return Zend_Cloud_DocumentService_Adapter_SimpleDb_Query but returns object\.#'
         - '#Method Zend_Cloud_DocumentService_Adapter_WindowsAzure::select\(\) should return Zend_Cloud_DocumentService_Query but returns object\.#'
         - '#Method Zend_Cloud_StorageService_Factory::getAdapter\(\) should return Zend_Cloud_StorageService_Adapter but returns Zend_Cloud_DocumentService_Adapter\|Zend_Cloud_QueueService_Adapter\|Zend_Cloud_StorageService_Adapter\.#'
@@ -133,7 +145,9 @@ parameters:
         - '#Property Zend_Service_Rackspace_Abstract::\$token \(string\) does not accept array\|string\|null\.#'
         - '#Property Zend_Soap_Wsdl::\$_dom \(DOMDocument\) does not accept DOMDocument\|false\|SimpleXMLElement\.#'
         - '#Static property Zend_Navigation_Page_Mvc::\$_urlHelper \(Zend_Controller_Action_Helper_Url\) does not accept Zend_Controller_Action_Helper_Abstract\.#'
+        #########################################################
         # Level 4 errors that require code changes
+        #########################################################
         - '#Call to function is_float\(\) will always evaluate to false\.#'
         - '#Call to function is_null\(\) will always evaluate to false\.#'
         - '#Call to function is_numeric\(\) will always evaluate to false\.#'
@@ -143,9 +157,16 @@ parameters:
         - '#Method Zend_Db_Adapter_Pdo_Mssql::_quote\(\) should return string but returns float\|int\|string\.#'
         - '#Method Zend_Db_Adapter_Pdo_Sqlite::_quote\(\) should return string but returns float\|int\|string\.#'
         - '#Property Zend_Pdf_Style::\$_lineDashingPattern \(array\) does not accept array\|int\.#'
-        - '#Strict comparison using !== between .+ and null will always evaluate to true\.#'
+        # This one happens in Zend_Serializer_Adapter_Igbinary, it seems ZF is expecting igbinary_serialize to return false, but can't find any evidence that
+        # it does that.
+        - '#Strict comparison using === between string and false will always evaluate to false.#'
+        # This only happens in Zend_Service_Twitter:701, it seems intentional, since if it's not exactly "2" (int), then it throws an error. "false" applies here
         - '#Strict comparison using !== between bool and int will always evaluate to true\.#'
-        - '#Strict comparison using !== between null and .+ will always evaluate to true\.#'
-        - '#Strict comparison using === between .+ and null will always evaluate to false\.#'
+        # The object oriented style of DateTime does not return false, so this check probably doesn't need to be there in Zend_XmlRpc_Value_DateTime:67
         - '#Strict comparison using === between DateTime and false will always evaluate to false\.#'
+        # These are typically checking function arguments (or returns from other functions that don't explicitly say they return null) to make sure they were set to something,
+        # and without scalar type-hints, has to be done
+        - '#Strict comparison using === between .+ and null will always evaluate to false\.#'
         - '#Strict comparison using === between null and .+ will always evaluate to false\.#'
+        - '#Strict comparison using !== between null and .+ will always evaluate to true\.#'
+        - '#Strict comparison using !== between .+ and null will always evaluate to true\.#'


### PR DESCRIPTION
I stumbled on the phpstorm-stubs project via some issues in phpstan's issue tracker and thought they might be of use here since we had to ignore quite a few phpstan errors due to missing extensions either locally or on travis.

I've added some checks in the phpstan-bootstrap file to include the necessary stub when an extension is missing, and updated the phpstan ignores a bit.

Also some more improvements to the docblocks.

I'll document code changes inline.